### PR TITLE
nextjs: simplify check in useEffect

### DIFF
--- a/examples/nextjs/app/page.js
+++ b/examples/nextjs/app/page.js
@@ -12,9 +12,8 @@ export default function App() {
   useEffect(() => {
     const container = containerRef.current;
 
-    if (container && typeof PSPDFKit !== "undefined" && window.PSPDFKit) {
-      const { PSPDFKit } = window;
-
+    const { PSPDFKit } = window;
+    if (container && PSPDFKit) {
       PSPDFKit.load({
         container,
         document: "/example.pdf",
@@ -22,7 +21,9 @@ export default function App() {
       });
     }
 
-    return () => PSPDFKit?.unload(container);
+    return () => {
+      PSPDFKit?.unload(container);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
- Remove check for `undefined`
- Change the cleanup function to not return anything (in-line with `useEffect` typing)