### PR TITLE
Pin or update patched vite package versions.

### DIFF
--- a/examples/angular/package-lock.json
+++ b/examples/angular/package-lock.json
@@ -12059,9 +12059,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
+      "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",

--- a/examples/laravel/package-lock.json
+++ b/examples/laravel/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "laravel",
       "dependencies": {
         "@nutrient-sdk/viewer": "1.1.0"
       },

--- a/examples/nuxtjs/package-lock.json
+++ b/examples/nuxtjs/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@nutrient-sdk/viewer": "1.1.0",
-        "nuxt": "^3.14.1592",
+        "nuxt": "^3.16.1",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -88,12 +88,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
-      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dependencies": {
-        "@babel/parser": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -114,11 +114,11 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
-      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
       "dependencies": {
-        "@babel/compat-data": "^7.26.5",
+        "@babel/compat-data": "^7.26.8",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -137,16 +137,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz",
-      "integrity": "sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+      "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
         "@babel/helper-replace-supers": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-        "@babel/traverse": "^7.26.9",
+        "@babel/traverse": "^7.27.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -278,23 +278,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
-      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.10"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
-      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": {
-        "@babel/types": "^7.26.10"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -332,12 +332,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.8.tgz",
-      "integrity": "sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
+      "integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
-        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.27.0",
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9"
@@ -350,28 +350,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
-      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.10",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
-      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1199,16 +1199,16 @@
       }
     },
     "node_modules/@nuxt/kit": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.16.0.tgz",
-      "integrity": "sha512-yPfhk58BG6wJhELkGOTCOlkMDbZkizk3IaINcyTKm+hBKiK3SheLt7S9HStNL+qZSfH2Cf7A8sYp6M72lOIEtA==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.16.1.tgz",
+      "integrity": "sha512-Perby8hJGUeCWad5oTVXb/Ibvp18ZCUC5PxHHu+acMDmVfnxSo48yqk7qNd09VkTF3LEzoEjNZpmW2ZWN0ry7A==",
       "dependencies": {
         "c12": "^3.0.2",
-        "consola": "^3.4.0",
+        "consola": "^3.4.2",
         "defu": "^6.1.4",
         "destr": "^2.0.3",
         "errx": "^0.1.0",
-        "exsolve": "^1.0.2",
+        "exsolve": "^1.0.4",
         "globby": "^14.1.0",
         "ignore": "^7.0.3",
         "jiti": "^2.4.2",
@@ -1251,11 +1251,11 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.16.0.tgz",
-      "integrity": "sha512-uCpcqWO6C4P5c4vi1/sq5GyajO0EOp+ZWFtPrnKaJ1pXAhA+W1aMVxAjfi2f18QMJHuRXBz1TouFg1RmWA6FuA==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.16.1.tgz",
+      "integrity": "sha512-Ri8bmT6MljpVR4DlXf9+acfgGaI4OTEdAzJU5aF2rJS78abtpnBxjXBG65kuhoL1LUlfKppDl8fTkUw5LM2JXQ==",
       "dependencies": {
-        "consola": "^3.4.0",
+        "consola": "^3.4.2",
         "defu": "^6.1.4",
         "pathe": "^2.0.3",
         "std-env": "^3.8.1"
@@ -1300,21 +1300,21 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.16.0.tgz",
-      "integrity": "sha512-H/mRrDmpWWLIiF1J9jguCKITF0ydFxmgcBcbveQac6vVhaOZunBAv9SsKHZgnH8CDM1v5BnuRNyIQ9y4Y9wW8g==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.16.1.tgz",
+      "integrity": "sha512-6A/cK743xeGcoMh//Ev1HAybb5VDwovxRsNeubfuqlDxBR7WL695SAfIhEAmxpVDz8LYQBuz/NwGhTaBh7hgaQ==",
       "dependencies": {
-        "@nuxt/kit": "3.16.0",
+        "@nuxt/kit": "3.16.1",
         "@rollup/plugin-replace": "^6.0.2",
-        "@vitejs/plugin-vue": "^5.2.1",
-        "@vitejs/plugin-vue-jsx": "^4.1.1",
-        "autoprefixer": "^10.4.20",
-        "consola": "^3.4.0",
+        "@vitejs/plugin-vue": "^5.2.3",
+        "@vitejs/plugin-vue-jsx": "^4.1.2",
+        "autoprefixer": "^10.4.21",
+        "consola": "^3.4.2",
         "cssnano": "^7.0.6",
         "defu": "^6.1.4",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.25.1",
         "escape-string-regexp": "^5.0.0",
-        "exsolve": "^1.0.2",
+        "exsolve": "^1.0.4",
         "externality": "^1.0.2",
         "get-port-please": "^3.1.2",
         "h3": "^1.15.1",
@@ -1322,6 +1322,7 @@
         "knitwork": "^1.2.0",
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
+        "mocked-exports": "^0.1.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "perfect-debounce": "^1.0.0",
@@ -1330,11 +1331,11 @@
         "rollup-plugin-visualizer": "^5.14.0",
         "std-env": "^3.8.1",
         "ufo": "^1.5.4",
-        "unenv": "^2.0.0-rc.12",
-        "unplugin": "^2.2.0",
-        "vite": "^6.2.1",
-        "vite-node": "^3.0.8",
-        "vite-plugin-checker": "^0.9.0",
+        "unenv": "^2.0.0-rc.15",
+        "unplugin": "^2.2.1",
+        "vite": "^6.2.2",
+        "vite-node": "^3.0.9",
+        "vite-plugin-checker": "^0.9.1",
         "vue-bundle-renderer": "^2.1.1"
       },
       "engines": {
@@ -1364,22 +1365,10 @@
         "pathe": "^2.0.3"
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/unenv": {
-      "version": "2.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
-      "integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
-      "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.4",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.5.4"
-      }
-    },
     "node_modules/@nuxt/vite-builder/node_modules/unplugin": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.2.1.tgz",
-      "integrity": "sha512-Q0YDhwViJaSnHf1cxLf+/VKhmfdr/ZAS/RL2GQVO0cAbAfJAVUef2bvNu+veyWcEPNwsTlFmMiFLjf8Xeqog8g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.2.2.tgz",
+      "integrity": "sha512-Qp+iiD+qCRnUek+nDoYvtWX7tfnYyXsrOnJ452FRTgOyKmTM7TUJ3l+PLPJOOWPTUyKISKp4isC5JJPSXUjGgw==",
       "dependencies": {
         "acorn": "^8.14.1",
         "webpack-virtual-modules": "^0.6.2"
@@ -1539,12 +1528,20 @@
       }
     },
     "node_modules/@oxc-parser/wasm": {
-      "version": "0.56.5",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/wasm/-/wasm-0.56.5.tgz",
-      "integrity": "sha512-9vtn56ok7PHS0elihFP+Q+alveQuGR0vnF6OeZesxkKWLJr8mCk0kZJx5ZxLjibaPA/sxWTmOyn31UMM9jg9fg==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/wasm/-/wasm-0.60.0.tgz",
+      "integrity": "sha512-Dkf9/D87WGBCW3L0+1DtpAfL4SrNsgeRvxwjpKCtbH7Kf6K+pxrT0IridaJfmWKu1Ml+fDvj+7HEyBcfUC/TXQ==",
       "dependencies": {
-        "@oxc-project/types": "^0.56.5"
+        "@oxc-project/types": "^0.60.0"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-parser/wasm/node_modules/@oxc-project/types": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.60.0.tgz",
+      "integrity": "sha512-prhfNnb3ATFHOCv7mzKFfwLij5RzoUz6Y1n525ZhCEqfq5wreCXL+DyVoq3ShukPo7q45ZjYIdjFUgjj+WKzng==",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -3276,9 +3273,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001706",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
-      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
+      "version": "1.0.30001707",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
+      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4087,9 +4084,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.120",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz",
-      "integrity": "sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ=="
+      "version": "1.5.128",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.128.tgz",
+      "integrity": "sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -4706,16 +4703,32 @@
       "integrity": "sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw=="
     },
     "node_modules/impound": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/impound/-/impound-0.2.0.tgz",
-      "integrity": "sha512-gXgeSyp9Hf7qG2/PLKmywHXyQf2xFrw+mJGpoj9DsAB9L7/MIKn+DeEx98UryWXdmbv8wUUPdcQof6qXnZoCGg==",
-      "license": "MIT",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/impound/-/impound-0.2.2.tgz",
+      "integrity": "sha512-9CNg+Ly8QjH4FwCUoE9nl1zeqY1NPK1s1P6Btp4L8lJxn8oZLN/0p6RZhitnyEL0BnVWrcVPfbs0Q3x+O/ucHg==",
       "dependencies": {
-        "@rollup/pluginutils": "^5.1.2",
-        "mlly": "^1.7.2",
-        "pathe": "^1.1.2",
-        "unenv": "^1.10.0",
-        "unplugin": "^1.14.1"
+        "@rollup/pluginutils": "^5.1.4",
+        "mlly": "^1.7.4",
+        "mocked-exports": "^0.1.0",
+        "pathe": "^2.0.3",
+        "unplugin": "^2.2.0"
+      }
+    },
+    "node_modules/impound/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "node_modules/impound/node_modules/unplugin": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.2.2.tgz",
+      "integrity": "sha512-Qp+iiD+qCRnUek+nDoYvtWX7tfnYyXsrOnJ452FRTgOyKmTM7TUJ3l+PLPJOOWPTUyKISKp4isC5JJPSXUjGgw==",
+      "dependencies": {
+        "acorn": "^8.14.1",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
       }
     },
     "node_modules/index-to-position": {
@@ -5390,6 +5403,11 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
+    "node_modules/mocked-exports": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mocked-exports/-/mocked-exports-0.1.1.tgz",
+      "integrity": "sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA=="
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5583,18 +5601,6 @@
         "confbox": "^0.2.1",
         "exsolve": "^1.0.1",
         "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/nitropack/node_modules/unenv": {
-      "version": "2.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
-      "integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
-      "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.4",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.5.4"
       }
     },
     "node_modules/nitropack/node_modules/unstorage": {
@@ -5813,45 +5819,46 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.16.0.tgz",
-      "integrity": "sha512-4j2tuHo+kcComQ1WrCD+i1w3UFOHrcnNH30cwiEY/WZZlBZOlC6DtUm6aBjhfpBFaMYsF4PbyKsNW+7FHwckHA==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.16.1.tgz",
+      "integrity": "sha512-V0odAW9Yo8s58yGnSy0RuX+rQwz0wtQp3eOgMTsh1YDDZdIIYZmAlZaLypNeieO/mbmvOOUcnuRyIGIRrF4+5A==",
       "dependencies": {
-        "@nuxt/cli": "^3.22.5",
+        "@nuxt/cli": "^3.23.1",
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/devtools": "^2.2.1",
-        "@nuxt/kit": "3.16.0",
-        "@nuxt/schema": "3.16.0",
-        "@nuxt/telemetry": "^2.6.5",
-        "@nuxt/vite-builder": "3.16.0",
-        "@oxc-parser/wasm": "^0.56.4",
-        "@unhead/vue": "^2.0.0-rc.7",
+        "@nuxt/devtools": "^2.3.0",
+        "@nuxt/kit": "3.16.1",
+        "@nuxt/schema": "3.16.1",
+        "@nuxt/telemetry": "^2.6.6",
+        "@nuxt/vite-builder": "3.16.1",
+        "@oxc-parser/wasm": "^0.60.0",
+        "@unhead/vue": "^2.0.0-rc.13",
         "@vue/shared": "^3.5.13",
         "c12": "^3.0.2",
         "chokidar": "^4.0.3",
         "compatx": "^0.1.8",
-        "consola": "^3.4.0",
+        "consola": "^3.4.2",
         "cookie-es": "^2.0.0",
         "defu": "^6.1.4",
         "destr": "^2.0.3",
         "devalue": "^5.1.1",
         "errx": "^0.1.0",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.25.1",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
-        "exsolve": "^1.0.2",
+        "exsolve": "^1.0.4",
         "globby": "^14.1.0",
         "h3": "^1.15.1",
         "hookable": "^5.5.3",
         "ignore": "^7.0.3",
-        "impound": "^0.2.0",
+        "impound": "^0.2.2",
         "jiti": "^2.4.2",
         "klona": "^2.0.6",
         "knitwork": "^1.2.0",
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
+        "mocked-exports": "^0.1.1",
         "nanotar": "^0.2.0",
-        "nitropack": "^2.11.5",
+        "nitropack": "^2.11.7",
         "nypm": "^0.6.0",
         "ofetch": "^1.4.1",
         "ohash": "^2.0.11",
@@ -5870,9 +5877,8 @@
         "ultrahtml": "^1.5.3",
         "uncrypto": "^0.1.3",
         "unctx": "^2.4.1",
-        "unenv": "^2.0.0-rc.12",
         "unimport": "^4.1.2",
-        "unplugin": "^2.2.0",
+        "unplugin": "^2.2.1",
         "unplugin-vue-router": "^0.12.0",
         "unstorage": "^1.15.0",
         "untyped": "^2.0.0",
@@ -5924,18 +5930,6 @@
         "confbox": "^0.2.1",
         "exsolve": "^1.0.1",
         "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/nuxt/node_modules/unenv": {
-      "version": "2.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
-      "integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
-      "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.4",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.5.4"
       }
     },
     "node_modules/nuxt/node_modules/unplugin": {
@@ -7961,29 +7955,21 @@
       }
     },
     "node_modules/unenv": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
-      "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
-      "license": "MIT",
+      "version": "2.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
+      "integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
       "dependencies": {
-        "consola": "^3.2.3",
         "defu": "^6.1.4",
-        "mime": "^3.0.0",
-        "node-fetch-native": "^1.6.4",
-        "pathe": "^1.1.2"
+        "exsolve": "^1.0.4",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
       }
     },
-    "node_modules/unenv/node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "node_modules/unhead": {
       "version": "2.0.0-rc.13",
@@ -8236,9 +8222,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",

--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@nutrient-sdk/viewer": "1.1.0",
-    "nuxt": "^3.14.1592",
+    "nuxt": "^3.16.1",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/examples/svelte-kit/package.json
+++ b/examples/svelte-kit/package.json
@@ -19,7 +19,7 @@
     "svelte": "^5.25.3",
     "svelte-check": "^4.1.5",
     "typescript": "^5.0.0",
-    "vite": "^6.2.2"
+    "vite": "^6.2.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild"],

--- a/examples/svelte-kit/pnpm-lock.yaml
+++ b/examples/svelte-kit/pnpm-lock.yaml
@@ -17,13 +17,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^4.0.0
-        version: 4.0.0(@sveltejs/kit@2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))
+        version: 4.0.0(@sveltejs/kit@2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))
       '@sveltejs/kit':
         specifier: ^2.20.2
-        version: 2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))
+        version: 2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))
+        version: 5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))
       rollup-plugin-copy:
         specifier: ^3.5.0
         version: 3.5.0
@@ -37,8 +37,8 @@ importers:
         specifier: ^5.0.0
         version: 5.7.3
       vite:
-        specifier: ^6.2.2
-        version: 6.2.2(@types/node@22.13.2)
+        specifier: ^6.2.3
+        version: 6.2.3(@types/node@22.13.2)
 
 packages:
 
@@ -679,8 +679,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  vite@6.2.2:
-    resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
+  vite@6.2.3:
+    resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -911,14 +911,14 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
-  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))':
+  '@sveltejs/adapter-auto@4.0.0(@sveltejs/kit@2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))':
     dependencies:
-      '@sveltejs/kit': 2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))
+      '@sveltejs/kit': 2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))':
+  '@sveltejs/kit@2.20.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))
       '@types/cookie': 0.6.0
       cookie: 0.7.2
       devalue: 5.1.1
@@ -931,27 +931,27 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.0
       svelte: 5.25.3
-      vite: 6.2.2(@types/node@22.13.2)
+      vite: 6.2.3(@types/node@22.13.2)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))
       debug: 4.4.0
       svelte: 5.25.3
-      vite: 6.2.2(@types/node@22.13.2)
+      vite: 6.2.3(@types/node@22.13.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.2(@types/node@22.13.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2)))(svelte@5.25.3)(vite@6.2.3(@types/node@22.13.2))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.25.3
-      vite: 6.2.2(@types/node@22.13.2)
-      vitefu: 1.0.5(vite@6.2.2(@types/node@22.13.2))
+      vite: 6.2.3(@types/node@22.13.2)
+      vitefu: 1.0.5(vite@6.2.3(@types/node@22.13.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -1289,7 +1289,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  vite@6.2.2(@types/node@22.13.2):
+  vite@6.2.3(@types/node@22.13.2):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -1298,9 +1298,9 @@ snapshots:
       '@types/node': 22.13.2
       fsevents: 2.3.3
 
-  vitefu@1.0.5(vite@6.2.2(@types/node@22.13.2)):
+  vitefu@1.0.5(vite@6.2.3(@types/node@22.13.2)):
     optionalDependencies:
-      vite: 6.2.2(@types/node@22.13.2)
+      vite: 6.2.3(@types/node@22.13.2)
 
   wrappy@1.0.2: {}
 

--- a/examples/vite/package-lock.json
+++ b/examples/vite/package-lock.json
@@ -17,7 +17,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "rollup": "^4.22.4",
         "rollup-plugin-copy": "^3.5.0",
-        "vite": "^6.2.2"
+        "vite": "^6.2.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -34,6 +34,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "rollup": "^4.22.4",
     "rollup-plugin-copy": "^3.5.0",
-    "vite": "^6.2.2"
+    "vite": "^6.2.3"
   }
 }

--- a/examples/vue-composition-api/package.json
+++ b/examples/vue-composition-api/package.json
@@ -22,8 +22,13 @@
     "npm-run-all2": "^7.0.2",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "~5.7.3",
-    "vite": "^6.2.2",
+    "vite": "^6.2.3",
     "vite-plugin-vue-devtools": "^7.7.2",
     "vue-tsc": "^2.2.8"
+  },
+  "pnpm": {
+    "overrides": {
+      "@babel/helpers": "^7.26.10"
+    }
   }
 }

--- a/examples/vue-composition-api/pnpm-lock.yaml
+++ b/examples/vue-composition-api/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@babel/helpers': ^7.26.10
+
 importers:
 
   .:
@@ -23,7 +26,7 @@ importers:
         version: 22.12.0
       '@vitejs/plugin-vue':
         specifier: ^5.2.3
-        version: 5.2.3(vite@6.2.2(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
+        version: 5.2.3(vite@6.2.3(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
@@ -37,11 +40,11 @@ importers:
         specifier: ~5.7.3
         version: 5.7.3
       vite:
-        specifier: ^6.2.2
-        version: 6.2.2(@types/node@22.12.0)
+        specifier: ^6.2.3
+        version: 6.2.3(@types/node@22.12.0)
       vite-plugin-vue-devtools:
         specifier: ^7.7.2
-        version: 7.7.2(rollup@4.32.1)(vite@6.2.2(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
+        version: 7.7.2(rollup@4.32.1)(vite@6.2.3(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.8(typescript@5.7.3)
@@ -129,12 +132,17 @@ packages:
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.26.7':
-    resolution: {integrity: sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==}
+  '@babel/helpers@7.27.0':
+    resolution: {integrity: sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.26.7':
     resolution: {integrity: sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -183,12 +191,20 @@ packages:
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.27.0':
+    resolution: {integrity: sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.26.7':
     resolution: {integrity: sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.7':
     resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.0':
+    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.25.1':
@@ -1147,8 +1163,8 @@ packages:
     peerDependencies:
       vite: ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0
 
-  vite@6.2.2:
-    resolution: {integrity: sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==}
+  vite@6.2.3:
+    resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -1248,7 +1264,7 @@ snapshots:
       '@babel/generator': 7.26.5
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.7)
-      '@babel/helpers': 7.26.7
+      '@babel/helpers': 7.27.0
       '@babel/parser': 7.26.7
       '@babel/template': 7.25.9
       '@babel/traverse': 7.26.7
@@ -1345,14 +1361,18 @@ snapshots:
 
   '@babel/helper-validator-option@7.25.9': {}
 
-  '@babel/helpers@7.26.7':
+  '@babel/helpers@7.27.0':
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.7
+      '@babel/template': 7.27.0
+      '@babel/types': 7.27.0
 
   '@babel/parser@7.26.7':
     dependencies:
       '@babel/types': 7.26.7
+
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.27.0
 
   '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.26.7)':
     dependencies:
@@ -1405,6 +1425,12 @@ snapshots:
       '@babel/parser': 7.26.7
       '@babel/types': 7.26.7
 
+  '@babel/template@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
+
   '@babel/traverse@7.26.7':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -1418,6 +1444,11 @@ snapshots:
       - supports-color
 
   '@babel/types@7.26.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.27.0':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
@@ -1627,9 +1658,9 @@ snapshots:
       '@types/prop-types': 15.7.14
       csstype: 3.1.3
 
-  '@vitejs/plugin-vue@5.2.3(vite@6.2.2(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.3(vite@6.2.3(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 6.2.2(@types/node@22.12.0)
+      vite: 6.2.3(@types/node@22.12.0)
       vue: 3.5.13(typescript@5.7.3)
 
   '@volar/language-core@2.4.11':
@@ -1709,14 +1740,14 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/devtools-core@7.7.2(vite@6.2.2(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))':
+  '@vue/devtools-core@7.7.2(vite@6.2.3(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.2
       '@vue/devtools-shared': 7.7.2
       mitt: 3.0.1
       nanoid: 5.0.9
       pathe: 2.0.2
-      vite-hot-client: 0.2.4(vite@6.2.2(@types/node@22.12.0))
+      vite-hot-client: 0.2.4(vite@6.2.3(@types/node@22.12.0))
       vue: 3.5.13(typescript@5.7.3)
     transitivePeerDependencies:
       - vite
@@ -2256,11 +2287,11 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite-hot-client@0.2.4(vite@6.2.2(@types/node@22.12.0)):
+  vite-hot-client@0.2.4(vite@6.2.3(@types/node@22.12.0)):
     dependencies:
-      vite: 6.2.2(@types/node@22.12.0)
+      vite: 6.2.3(@types/node@22.12.0)
 
-  vite-plugin-inspect@0.8.9(rollup@4.32.1)(vite@6.2.2(@types/node@22.12.0)):
+  vite-plugin-inspect@0.8.9(rollup@4.32.1)(vite@6.2.3(@types/node@22.12.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@4.32.1)
@@ -2271,28 +2302,28 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.0
-      vite: 6.2.2(@types/node@22.12.0)
+      vite: 6.2.3(@types/node@22.12.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vue-devtools@7.7.2(rollup@4.32.1)(vite@6.2.2(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3)):
+  vite-plugin-vue-devtools@7.7.2(rollup@4.32.1)(vite@6.2.3(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3)):
     dependencies:
-      '@vue/devtools-core': 7.7.2(vite@6.2.2(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
+      '@vue/devtools-core': 7.7.2(vite@6.2.3(@types/node@22.12.0))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-kit': 7.7.2
       '@vue/devtools-shared': 7.7.2
       execa: 9.5.2
       sirv: 3.0.0
-      vite: 6.2.2(@types/node@22.12.0)
-      vite-plugin-inspect: 0.8.9(rollup@4.32.1)(vite@6.2.2(@types/node@22.12.0))
-      vite-plugin-vue-inspector: 5.3.1(vite@6.2.2(@types/node@22.12.0))
+      vite: 6.2.3(@types/node@22.12.0)
+      vite-plugin-inspect: 0.8.9(rollup@4.32.1)(vite@6.2.3(@types/node@22.12.0))
+      vite-plugin-vue-inspector: 5.3.1(vite@6.2.3(@types/node@22.12.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.1(vite@6.2.2(@types/node@22.12.0)):
+  vite-plugin-vue-inspector@5.3.1(vite@6.2.3(@types/node@22.12.0)):
     dependencies:
       '@babel/core': 7.26.7
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.7)
@@ -2303,11 +2334,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: 6.2.2(@types/node@22.12.0)
+      vite: 6.2.3(@types/node@22.12.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.2.2(@types/node@22.12.0):
+  vite@6.2.3(@types/node@22.12.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3

--- a/examples/vue/package-lock.json
+++ b/examples/vue/package-lock.json
@@ -17,7 +17,7 @@
         "eslint": "^9.15.0",
         "eslint-plugin-vue": "^9.31.0",
         "ncp": "^2.0.0",
-        "vite": "^6.2.2"
+        "vite": "^6.2.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2351,9 +2351,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -19,7 +19,7 @@
     "eslint": "^9.15.0",
     "eslint-plugin-vue": "^9.31.0",
     "ncp": "^2.0.0",
-    "vite": "^6.2.2"
+    "vite": "^6.2.3"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
## Details

Solves these vulnerabilities (the same one in different examples, plus a Babel one):

https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/33 [Moderate]
https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/32 [Moderate]
https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/31 [Moderate]
https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/26 [Moderate]
https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/30 [Moderate]
https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/29 [Moderate]

This Laravel vulnerability is **not** addressed here, as it requires upgrading a major version and it'll be tackled separately (see https://pspdfkit.atlassian.net/browse/WEB-2701): https://github.com/PSPDFKit/nutrient-web-examples/security/dependabot/23 [Moderate]