### PR TITLE
Fix broken PWA link.

### DIFF
--- a/examples/pwa/src/index.html
+++ b/examples/pwa/src/index.html
@@ -117,7 +117,7 @@
         <p>
           The
           <a
-            href="https://github.com/PSPDFKit/nutrient-web-examples/examples/pwa"
+            href="https://github.com/PSPDFKit/nutrient-web-examples/tree/main/examples/pwa"
             target="_blank"
             rel="noopener"
             >PWA example</a


### PR DESCRIPTION
## Details

Fixes broken link to the PWA folder of the examples repo. See https://pspdfkit.slack.com/archives/C090BPMBJ/p1748874385956519?thread_ts=1748847641.907959&cid=C090BPMBJ