### PR TITLE
Fix wrong port in TypeScript README.md

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -29,7 +29,7 @@ We are ready to launch the app! 🎉
 npm start
 ```
 
-You can now open http://localhost:3000 in your browser and enjoy!
+You can now open http://localhost:8080 in your browser and enjoy!
 
 ## Support, Issues and License Questions
 


### PR DESCRIPTION
## Details

`npm run dev` will use the default port, 3000, but `npm start` is configured to use 8080 in the example, and it's the script we share in the README.md, so it needs amending.

See https://pspdfkit.slack.com/archives/C0GJ3587N/p1748894280774199