### PR TITLE
Update examples with Nutrient SDK version 1.4.0

### DIFF
--- a/examples/angular/package-lock.json
+++ b/examples/angular/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^19.2.9",
         "@angular/platform-browser-dynamic": "^19.2.9",
         "@angular/router": "^19.2.9",
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3821,9 +3821,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3951,9 +3951,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4676,9 +4676,9 @@
       }
     },
     "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5580,9 +5580,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5711,9 +5711,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7981,9 +7981,9 @@
       }
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^19.2.9",
     "@angular/platform-browser-dynamic": "^19.2.9",
     "@angular/router": "^19.2.9",
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/examples/electron-nodeintegration/package-lock.json
+++ b/examples/electron-nodeintegration/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0"
+        "@nutrient-sdk/viewer": "1.4.0"
       },
       "devDependencies": {
         "@electron/packager": "^18.3.6",
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -713,9 +713,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/examples/electron-nodeintegration/package.json
+++ b/examples/electron-nodeintegration/package.json
@@ -29,7 +29,7 @@
     "electron": "^33.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0"
+    "@nutrient-sdk/viewer": "1.4.0"
   },
   "overrides": {
     "minimatch": "^3.0.5",

--- a/examples/electron/package-lock.json
+++ b/examples/electron/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0"
+        "@nutrient-sdk/viewer": "1.4.0"
       },
       "devDependencies": {
         "@electron/packager": "^18.3.6",
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -702,9 +702,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -28,7 +28,7 @@
     "electron": "^33.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0"
+    "@nutrient-sdk/viewer": "1.4.0"
   },
   "overrides": {
     "minimatch": "^3.0.5",

--- a/examples/elm/package-lock.json
+++ b/examples/elm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0"
+        "@nutrient-sdk/viewer": "1.4.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^12.0.2",
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -833,9 +833,10 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/elm/package.json
+++ b/examples/elm/package.json
@@ -3,12 +3,7 @@
   "description": "PDF viewer web application built with Nutrient Web SDK and Elm",
   "version": "1.0.0",
   "main": "index.js",
-  "keywords": [
-    "elm",
-    "pdf",
-    "viewer",
-    "webpack"
-  ],
+  "keywords": ["elm", "pdf", "viewer", "webpack"],
   "author": "Nutrient (https://www.nutrient.io)",
   "homepage": "https://www.nutrient.io/web",
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",

--- a/examples/elm/package.json
+++ b/examples/elm/package.json
@@ -3,13 +3,18 @@
   "description": "PDF viewer web application built with Nutrient Web SDK and Elm",
   "version": "1.0.0",
   "main": "index.js",
-  "keywords": ["elm", "pdf", "viewer", "webpack"],
+  "keywords": [
+    "elm",
+    "pdf",
+    "viewer",
+    "webpack"
+  ],
   "author": "Nutrient (https://www.nutrient.io)",
   "homepage": "https://www.nutrient.io/web",
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0"
+    "@nutrient-sdk/viewer": "1.4.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",

--- a/examples/gatsbyjs/package-lock.json
+++ b/examples/gatsbyjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "gatsby": "^5.14.4",
         "gatsby-source-filesystem": "^5.14.0",
         "react": "^18.0.0",
@@ -2678,9 +2678,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5229,8 +5229,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "license": "MIT",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/gatsbyjs/package.json
+++ b/examples/gatsbyjs/package.json
@@ -17,7 +17,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "gatsby": "^5.14.4",
     "gatsby-source-filesystem": "^5.14.0",
     "react": "^18.0.0",

--- a/examples/gatsbyjs/src/templates/Viewport.js
+++ b/examples/gatsbyjs/src/templates/Viewport.js
@@ -25,7 +25,7 @@ const Viewport = (props) => {
       // Gatsby needs client-side only packages need to be imported asynchronously
       // https://www.gatsbyjs.com/docs/using-client-side-only-packages/
       nutrientScript.src =
-        "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.3.0/nutrient-viewer.js";
+        "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.4.0/nutrient-viewer.js";
       document.head.appendChild(nutrientScript);
 
       return () => {

--- a/examples/laravel/package-lock.json
+++ b/examples/laravel/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "laravel",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0"
+        "@nutrient-sdk/viewer": "1.4.0"
       },
       "devDependencies": {
         "axios": "^1.7.7",
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2844,9 +2844,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/examples/laravel/package.json
+++ b/examples/laravel/package.json
@@ -16,7 +16,7 @@
     "postcss": "^8.1.14"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0"
+    "@nutrient-sdk/viewer": "1.4.0"
   },
   "overrides": {
     "loader-utils@>= 0.0.0 < 2.0.0": "^1.4.2",

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "copy-webpack-plugin": "^13.0.0",
         "next": "^15.3.0",
         "react": "^19.0.0",
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "copy-webpack-plugin": "^13.0.0",
     "next": "^15.3.0",
     "react": "^19.0.0",

--- a/examples/nuxtjs/package-lock.json
+++ b/examples/nuxtjs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nutrient-web-example-nuxtjs",
       "version": "1.0.0",
       "dependencies": {
+        "@nutrient-sdk/viewer": "1.4.0",
         "nuxt": "^3.17.4",
         "vue": "^3.5.15"
       }
@@ -1637,6 +1638,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nutrient-sdk/viewer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
+      "dependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@nuxt/cli": {
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.25.1.tgz",
@@ -3078,6 +3087,20 @@
       "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg=="
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3888,9 +3911,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -11,6 +11,7 @@
     "start:e2e": "npm run dev"
   },
   "dependencies": {
+    "@nutrient-sdk/viewer": "1.4.0",
     "nuxt": "^3.17.4",
     "vue": "^3.5.15"
   }

--- a/examples/pwa/package-lock.json
+++ b/examples/pwa/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "idb": "^2.1.3",
         "serve": "^14.2.3",
         "workbox-sw": "^7.1.0"
@@ -1965,9 +1965,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2645,9 +2645,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/pwa/package.json
+++ b/examples/pwa/package.json
@@ -25,7 +25,7 @@
     "start:e2e": "npm run build && serve ./dist"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "idb": "^2.1.3",
     "serve": "^14.2.3",
     "workbox-sw": "^7.1.0"

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^13.0.0",
         "@testing-library/user-event": "^14.0.4",
@@ -2431,9 +2431,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4322,8 +4322,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "license": "MIT",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -19,7 +19,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^14.0.4",

--- a/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
+++ b/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
@@ -4,7 +4,7 @@
 
     <script type="text/javascript"> __sfdcSessionId = '{!$Api.Session_Id}';</script>
     <script src="../../soap/ajax/54.0/connection.js" type="text/javascript"></script>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.3.0/nutrient-viewer.js" type="text/javascript"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.4.0/nutrient-viewer.js" type="text/javascript"></script>
     <script type="text/javascript">
 
         var recId = '{!fileDetail}';
@@ -13,7 +13,7 @@
         var contVersion;
         var state;
         var pdf;
-        var baseUrl = `https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.3.0/`;
+        var baseUrl = `https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.4.0/`;
 
         const saveButton = {
             type: "custom",

--- a/examples/salesforce/package-lock.json
+++ b/examples/salesforce/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0"
+        "@nutrient-sdk/viewer": "1.4.0"
       },
       "devDependencies": {
         "@lwc/eslint-plugin-lwc": "^1.1.2",
@@ -786,9 +786,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1988,9 +1988,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3108,9 +3108,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4008,9 +4008,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4142,9 +4142,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4774,9 +4774,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9171,9 +9171,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/examples/salesforce/package.json
+++ b/examples/salesforce/package.json
@@ -47,6 +47,6 @@
     ]
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0"
+    "@nutrient-sdk/viewer": "1.4.0"
   }
 }

--- a/examples/svelte/package-lock.json
+++ b/examples/svelte/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "sirv-cli": "^2.0.2"
       },
       "devDependencies": {
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -21,7 +21,7 @@
     "svelte": "^4.2.19"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "sirv-cli": "^2.0.2"
   }
 }

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "serve": "^14.2.4"
       },
       "devDependencies": {
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -826,11 +826,10 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1452,9 +1451,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -21,7 +21,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "serve": "^14.2.4"
   },
   "devDependencies": {

--- a/examples/vite/package-lock.json
+++ b/examples/vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1181,11 +1181,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -26,7 +26,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/vue/package-lock.json
+++ b/examples/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-vue",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1240,9 +1240,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -27,10 +27,7 @@
       "node": true,
       "es2022": true
     },
-    "extends": [
-      "plugin:vue/vue3-essential",
-      "eslint:recommended"
-    ],
+    "extends": ["plugin:vue/vue3-essential", "eslint:recommended"],
     "parserOptions": {
       "requireConfigFile": false
     },

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -10,7 +10,7 @@
     "start:e2e": "npm run dev -- --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "vue": "^3.5.13"
   },
   "devDependencies": {
@@ -27,7 +27,10 @@
       "node": true,
       "es2022": true
     },
-    "extends": ["plugin:vue/vue3-essential", "eslint:recommended"],
+    "extends": [
+      "plugin:vue/vue3-essential",
+      "eslint:recommended"
+    ],
     "parserOptions": {
       "requireConfigFile": false
     },

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.3.0",
+        "@nutrient-sdk/viewer": "1.4.0",
         "drag-drop": "^7.2.0",
         "serve": "^14.2.4"
       },
@@ -149,9 +149,9 @@
       "license": "MIT"
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.3.0.tgz",
-      "integrity": "sha512-7i4d3RUXi2+Jdws0FyYohpmd0dK7nIRdGSJlREikkpxA4YRy4ckLWRAiU6UbyGHPX2CCUDwoiIFg22Zm5Evn0w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.4.0.tgz",
+      "integrity": "sha512-ak9oYnY0JSnJ81LyAhZil8TrToLFjXP4Nq7eh6wpbQLJIjixwHkBfRXFaCZGVSeXDV5ZkBChrOAMTHC89WIt+g==",
       "dependencies": {
         "@types/react": "^18.0.0"
       }
@@ -900,8 +900,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "license": "MIT",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.3.0",
+    "@nutrient-sdk/viewer": "1.4.0",
     "drag-drop": "^7.2.0",
     "serve": "^14.2.4"
   },


### PR DESCRIPTION
## Details
- Updated examples with Nutrient SDK version 1.4.0.
- PWA.
- Pin Biome version to 1.9.4 in GitHub workflow as "latest" will require some work as introduces some breaking changes with new set of defaults and "ignore" is no longer available and should use "include" instead.
