### PR TITLE
Update examples with Nutrient SDK version 1.14.0

### DIFF
--- a/examples/angular/package-lock.json
+++ b/examples/angular/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^21.2.0",
         "@angular/platform-browser-dynamic": "^21.2.0",
         "@angular/router": "^21.2.0",
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "~0.16.1"
@@ -4709,9 +4709,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/platform-browser-dynamic": "^21.2.0",
     "@angular/router": "^21.2.0",
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "~0.16.1"

--- a/examples/electron-nodeintegration/package-lock.json
+++ b/examples/electron-nodeintegration/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1"
+        "@nutrient-sdk/viewer": "1.14.0"
       },
       "devDependencies": {
         "@electron/packager": "^19.1.0",
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/examples/electron-nodeintegration/package.json
+++ b/examples/electron-nodeintegration/package.json
@@ -29,6 +29,6 @@
     "electron": "^41.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   }
 }

--- a/examples/electron/package-lock.json
+++ b/examples/electron/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1"
+        "@nutrient-sdk/viewer": "1.14.0"
       },
       "devDependencies": {
         "@electron/packager": "^19.1.0",
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -28,6 +28,6 @@
     "electron": "^41.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   }
 }

--- a/examples/elm/package-lock.json
+++ b/examples/elm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1"
+        "@nutrient-sdk/viewer": "1.14.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^14.0.0",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/elm/package.json
+++ b/examples/elm/package.json
@@ -9,7 +9,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^14.0.0",

--- a/examples/gatsbyjs/package-lock.json
+++ b/examples/gatsbyjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "gatsby": "^5.16.1",
         "gatsby-source-filesystem": "^5.16.0",
         "react": "^18.3.1",
@@ -3140,9 +3140,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/gatsbyjs/package.json
+++ b/examples/gatsbyjs/package.json
@@ -17,7 +17,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "gatsby": "^5.16.1",
     "gatsby-source-filesystem": "^5.16.0",
     "react": "^18.3.1",

--- a/examples/javascript-vite/index.html
+++ b/examples/javascript-vite/index.html
@@ -6,7 +6,7 @@
     <title>Nutrient Web SDK - JavaScript + Vite Example</title>
     <link rel="stylesheet" href="/src/style.css" />
     <!-- Load Nutrient Web SDK from CDN (comment out or remove when using npm package) -->
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
   </head>
   <body>
     <header>

--- a/examples/javascript-vite/package-lock.json
+++ b/examples/javascript-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "drag-drop": "^7.2.0"
       },
       "devDependencies": {
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/javascript-vite/package.json
+++ b/examples/javascript-vite/package.json
@@ -13,7 +13,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "drag-drop": "^7.2.0"
   },
   "devDependencies": {

--- a/examples/laravel/package-lock.json
+++ b/examples/laravel/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "laravel",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1"
+        "@nutrient-sdk/viewer": "1.14.0"
       },
       "devDependencies": {
         "axios": "^1.15.0",
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/laravel/package.json
+++ b/examples/laravel/package.json
@@ -16,7 +16,7 @@
     "postcss": "^8.5.9"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   },
   "overrides": {
     "webpack-dev-server": "^5.2.3",

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "copy-webpack-plugin": "^14.0.0",
         "next": "^15.5.8",
         "react": "^19.2.3",
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "copy-webpack-plugin": "^14.0.0",
     "next": "^15.5.8",
     "react": "^19.2.3",

--- a/examples/nuxtjs/package-lock.json
+++ b/examples/nuxtjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-nuxtjs",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "nuxt": "^3.20.2",
         "vue": "^3.5.25"
       }
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -11,7 +11,7 @@
     "start:e2e": "npm run dev"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "nuxt": "^3.20.2",
     "vue": "^3.5.25"
   },

--- a/examples/pwa/package-lock.json
+++ b/examples/pwa/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "idb": "^2.1.3",
         "serve": "^14.2.4",
         "workbox-sw": "^7.4.0"
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/pwa/package.json
+++ b/examples/pwa/package.json
@@ -25,7 +25,7 @@
     "start:e2e": "npm run build && serve ./dist"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "idb": "^2.1.3",
     "serve": "^14.2.4",
     "workbox-sw": "^7.4.0"

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2988,9 +2988,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -29,7 +29,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
+++ b/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
@@ -4,7 +4,7 @@
 
     <script type="text/javascript"> __sfdcSessionId = '{!$Api.Session_Id}';</script>
     <script src="../../soap/ajax/54.0/connection.js" type="text/javascript"></script>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/nutrient-viewer.js" type="text/javascript"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js" type="text/javascript"></script>
     <script type="text/javascript">
 
         var recId = '{!fileDetail}';
@@ -13,7 +13,7 @@
         var contVersion;
         var state;
         var pdf;
-        var baseUrl = "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/";
+        var baseUrl = "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/";
 
         const saveButton = {
             type: "custom",

--- a/examples/salesforce/package-lock.json
+++ b/examples/salesforce/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1"
+        "@nutrient-sdk/viewer": "1.14.0"
       },
       "devDependencies": {
         "@lwc/eslint-plugin-lwc": "^1.1.2",
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/salesforce/package.json
+++ b/examples/salesforce/package.json
@@ -48,6 +48,6 @@
     ]
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   }
 }

--- a/examples/svelte-kit/package.json
+++ b/examples/svelte-kit/package.json
@@ -35,6 +35,6 @@
     }
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   }
 }

--- a/examples/svelte-kit/pnpm-lock.yaml
+++ b/examples/svelte-kit/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@nutrient-sdk/viewer':
-        specifier: 1.13.1
-        version: 1.13.1
+        specifier: 1.14.0
+        version: 1.14.0
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
@@ -254,8 +254,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.13.1':
-    resolution: {integrity: sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==}
+  '@nutrient-sdk/viewer@1.14.0':
+    resolution: {integrity: sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==}
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
@@ -298,36 +298,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -619,24 +625,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -993,7 +1003,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@nutrient-sdk/viewer@1.13.1':
+  '@nutrient-sdk/viewer@1.14.0':
     dependencies:
       '@types/react': 18.3.19
 

--- a/examples/svelte/package-lock.json
+++ b/examples/svelte/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "sirv-cli": "^2.0.2"
       },
       "devDependencies": {
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -21,7 +21,7 @@
     "svelte": "^5.53.6"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "sirv-cli": "^2.0.2"
   },
   "overrides": {

--- a/examples/typescript-vite/index.html
+++ b/examples/typescript-vite/index.html
@@ -7,7 +7,7 @@
     <title>Nutrient Web SDK viewer — TypeScript example</title>
   </head>
   <body>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
     <div class="container"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/examples/typescript-vite/package-lock.json
+++ b/examples/typescript-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-typescript-vite-example",
       "version": "0.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1"
+        "@nutrient-sdk/viewer": "1.14.0"
       },
       "devDependencies": {
         "typescript": "^5.9.2",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/typescript-vite/package.json
+++ b/examples/typescript-vite/package.json
@@ -14,6 +14,6 @@
     "vite": "^8.0.9"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1"
+    "@nutrient-sdk/viewer": "1.14.0"
   }
 }

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "serve": "^13.0.4"
       },
       "devDependencies": {
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -21,7 +21,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "serve": "^13.0.4"
   },
   "devDependencies": {

--- a/examples/typescript/src/index.html
+++ b/examples/typescript/src/index.html
@@ -8,7 +8,7 @@
     />
     <title>Nutrient Web SDK - Typescript example</title>
     <link rel="stylesheet" href="index.css" />
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
   </head>
   <body>
     <div>

--- a/examples/vite/package-lock.json
+++ b/examples/vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -26,7 +26,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/examples/vue-composition-api/package.json
+++ b/examples/vue-composition-api/package.json
@@ -11,7 +11,7 @@
     "type-check": "vue-tsc --build"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/vue-composition-api/pnpm-lock.yaml
+++ b/examples/vue-composition-api/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@nutrient-sdk/viewer':
-        specifier: 1.13.1
-        version: 1.13.1
+        specifier: 1.14.0
+        version: 1.14.0
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@5.9.3)
@@ -395,8 +395,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.13.1':
-    resolution: {integrity: sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==}
+  '@nutrient-sdk/viewer@1.14.0':
+    resolution: {integrity: sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==}
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
@@ -438,66 +438,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -709,9 +722,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -939,24 +949,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1598,7 +1612,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@nutrient-sdk/viewer@1.13.1':
+  '@nutrient-sdk/viewer@1.14.0':
     dependencies:
       '@types/react': 18.3.19
 
@@ -1705,7 +1719,7 @@ snapshots:
   '@types/react@18.3.19':
     dependencies:
       '@types/prop-types': 15.7.14
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@vitejs/plugin-vue@6.0.6(vite@7.3.2(@types/node@22.12.0)(lightningcss@1.32.0))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
@@ -1918,8 +1932,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 

--- a/examples/vue/package-lock.json
+++ b/examples/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-vue",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "vue": "^3.5.32"
       },
       "devDependencies": {
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -10,7 +10,7 @@
     "start:e2e": "npm run dev -- --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -50,7 +50,7 @@ To use the npm package bundled with webpack instead of CDN:
 1. **Comment out the CDN script** in `src/index.html`:
    ```html
    <!-- Comment this line: -->
-   <!-- <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/nutrient-viewer.js"></script> -->
+   <!-- <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script> -->
    ```
 
 2. **Run with npm flag**:

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.13.1",
+        "@nutrient-sdk/viewer": "1.14.0",
         "drag-drop": "^7.2.0",
         "serve": "^13.0.4"
       },
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.13.1.tgz",
-      "integrity": "sha512-ofuvrgmfLt6IWT5u4aHh69pcPn+pRNhA19L9Q/jYsz0rFsh13p6R0D8l3kX+K1Gnw8llV2V7FJu3sffZY/m7Zg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
+      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.13.1",
+    "@nutrient-sdk/viewer": "1.14.0",
     "drag-drop": "^7.2.0",
     "serve": "^13.0.4"
   },

--- a/examples/webpack/src/index.html
+++ b/examples/webpack/src/index.html
@@ -9,7 +9,7 @@
     <title>Nutrient</title>
     <link rel="stylesheet" href="./index.css" />
     <!-- Load Nutrient Web SDK from CDN (comment out to use npm package instead) -->
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.13.1/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
   </head>
   <body id="body">
     <header>


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Type

- [ ] New framework example
- [ ] Update existing example
- [ ] SDK version bump
- [ ] Bug fix
- [ ] Repo infrastructure (CI, scripts, docs)

## Checklist

- [ ] `npm run format` passes (Biome)
- [ ] Example has `start` and `start:e2e` scripts in `package.json`
- [ ] `SERVER_DIR=examples/<name> npm run test` passes (Playwright smoke test)
- [ ] `README.md` included with prerequisites, setup, and usage
- [ ] Uses current pinned `@nutrient-sdk/viewer` version
