### PR TITLE
Update examples with Nutrient SDK version 1.15.0

### DIFF
--- a/examples/angular/package-lock.json
+++ b/examples/angular/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^21.2.0",
         "@angular/platform-browser-dynamic": "^21.2.0",
         "@angular/router": "^21.2.0",
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "~0.16.1"
@@ -4709,9 +4709,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/platform-browser-dynamic": "^21.2.0",
     "@angular/router": "^21.2.0",
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "~0.16.1"

--- a/examples/electron-nodeintegration/package-lock.json
+++ b/examples/electron-nodeintegration/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0"
+        "@nutrient-sdk/viewer": "1.15.0"
       },
       "devDependencies": {
         "@electron/packager": "^19.1.0",
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/electron-nodeintegration/package.json
+++ b/examples/electron-nodeintegration/package.json
@@ -29,6 +29,6 @@
     "electron": "^41.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0"
+    "@nutrient-sdk/viewer": "1.15.0"
   }
 }

--- a/examples/electron/package-lock.json
+++ b/examples/electron/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0"
+        "@nutrient-sdk/viewer": "1.15.0"
       },
       "devDependencies": {
         "@electron/packager": "^19.1.0",
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -28,6 +28,6 @@
     "electron": "^41.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0"
+    "@nutrient-sdk/viewer": "1.15.0"
   }
 }

--- a/examples/elm/package-lock.json
+++ b/examples/elm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0"
+        "@nutrient-sdk/viewer": "1.15.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^14.0.0",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/elm/package.json
+++ b/examples/elm/package.json
@@ -9,7 +9,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0"
+    "@nutrient-sdk/viewer": "1.15.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^14.0.0",

--- a/examples/gatsbyjs/package-lock.json
+++ b/examples/gatsbyjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "gatsby": "^5.16.1",
         "gatsby-source-filesystem": "^5.16.0",
         "react": "^18.3.1",
@@ -3140,9 +3140,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/gatsbyjs/package.json
+++ b/examples/gatsbyjs/package.json
@@ -17,7 +17,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "gatsby": "^5.16.1",
     "gatsby-source-filesystem": "^5.16.0",
     "react": "^18.3.1",

--- a/examples/javascript-vite/index.html
+++ b/examples/javascript-vite/index.html
@@ -6,7 +6,7 @@
     <title>Nutrient Web SDK - JavaScript + Vite Example</title>
     <link rel="stylesheet" href="/src/style.css" />
     <!-- Load Nutrient Web SDK from CDN (comment out or remove when using npm package) -->
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/nutrient-viewer.js"></script>
   </head>
   <body>
     <header>

--- a/examples/javascript-vite/package-lock.json
+++ b/examples/javascript-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "drag-drop": "^7.2.0"
       },
       "devDependencies": {
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/javascript-vite/package.json
+++ b/examples/javascript-vite/package.json
@@ -13,7 +13,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "drag-drop": "^7.2.0"
   },
   "devDependencies": {

--- a/examples/laravel/package-lock.json
+++ b/examples/laravel/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "laravel",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0"
+        "@nutrient-sdk/viewer": "1.15.0"
       },
       "devDependencies": {
         "axios": "^1.15.0",
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/laravel/package.json
+++ b/examples/laravel/package.json
@@ -16,7 +16,7 @@
     "postcss": "^8.5.9"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0"
+    "@nutrient-sdk/viewer": "1.15.0"
   },
   "overrides": {
     "webpack-dev-server": "^5.2.3",

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "copy-webpack-plugin": "^14.0.0",
         "next": "^15.5.8",
         "react": "^19.2.3",
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "copy-webpack-plugin": "^14.0.0",
     "next": "^15.5.8",
     "react": "^19.2.3",

--- a/examples/nuxtjs/package-lock.json
+++ b/examples/nuxtjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-nuxtjs",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "nuxt": "^3.20.2",
         "vue": "^3.5.25"
       }
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"
@@ -5289,9 +5289,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/diff": {

--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -11,7 +11,7 @@
     "start:e2e": "npm run dev"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "nuxt": "^3.20.2",
     "vue": "^3.5.25"
   },

--- a/examples/pwa/package-lock.json
+++ b/examples/pwa/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "idb": "^2.1.3",
         "serve": "^14.2.4",
         "workbox-sw": "^7.4.0"
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/pwa/package.json
+++ b/examples/pwa/package.json
@@ -25,7 +25,7 @@
     "start:e2e": "npm run build && serve ./dist"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "idb": "^2.1.3",
     "serve": "^14.2.4",
     "workbox-sw": "^7.4.0"

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -3000,9 +3000,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -29,7 +29,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
+++ b/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
@@ -4,7 +4,7 @@
 
     <script type="text/javascript"> __sfdcSessionId = '{!$Api.Session_Id}';</script>
     <script src="../../soap/ajax/54.0/connection.js" type="text/javascript"></script>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js" type="text/javascript"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/nutrient-viewer.js" type="text/javascript"></script>
     <script type="text/javascript">
 
         var recId = '{!fileDetail}';
@@ -13,7 +13,7 @@
         var contVersion;
         var state;
         var pdf;
-        var baseUrl = "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/";
+        var baseUrl = "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/";
 
         const saveButton = {
             type: "custom",

--- a/examples/salesforce/package-lock.json
+++ b/examples/salesforce/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0"
+        "@nutrient-sdk/viewer": "1.15.0"
       },
       "devDependencies": {
         "@lwc/eslint-plugin-lwc": "^1.1.2",
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/salesforce/package.json
+++ b/examples/salesforce/package.json
@@ -48,6 +48,6 @@
     ]
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0"
+    "@nutrient-sdk/viewer": "1.15.0"
   }
 }

--- a/examples/svelte/package-lock.json
+++ b/examples/svelte/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "sirv-cli": "^2.0.2"
       },
       "devDependencies": {
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "dev": true,
       "license": "MIT"
     },
@@ -908,13 +908,21 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
-      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.8.tgz",
+      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/estree-walker": {
@@ -1808,9 +1816,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.53.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.7.tgz",
-      "integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1823,9 +1831,9 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -21,7 +21,7 @@
     "svelte": "^5.53.6"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "sirv-cli": "^2.0.2"
   },
   "overrides": {

--- a/examples/typescript-vite/index.html
+++ b/examples/typescript-vite/index.html
@@ -7,7 +7,7 @@
     <title>Nutrient Web SDK viewer — TypeScript example</title>
   </head>
   <body>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/nutrient-viewer.js"></script>
     <div class="container"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/examples/typescript-vite/package-lock.json
+++ b/examples/typescript-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-typescript-vite-example",
       "version": "0.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0"
+        "@nutrient-sdk/viewer": "1.15.0"
       },
       "devDependencies": {
         "typescript": "^5.9.2",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/typescript-vite/package.json
+++ b/examples/typescript-vite/package.json
@@ -14,6 +14,6 @@
     "vite": "^8.0.9"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0"
+    "@nutrient-sdk/viewer": "1.15.0"
   }
 }

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "serve": "^13.0.4"
       },
       "devDependencies": {
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -21,7 +21,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "serve": "^13.0.4"
   },
   "devDependencies": {

--- a/examples/typescript/src/index.html
+++ b/examples/typescript/src/index.html
@@ -8,7 +8,7 @@
     />
     <title>Nutrient Web SDK - Typescript example</title>
     <link rel="stylesheet" href="index.css" />
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/nutrient-viewer.js"></script>
   </head>
   <body>
     <div>

--- a/examples/vite/package-lock.json
+++ b/examples/vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -26,7 +26,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/examples/vue/package-lock.json
+++ b/examples/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-vue",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "vue": "^3.5.32"
       },
       "devDependencies": {
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -10,7 +10,7 @@
     "start:e2e": "npm run dev -- --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -50,7 +50,7 @@ To use the npm package bundled with webpack instead of CDN:
 1. **Comment out the CDN script** in `src/index.html`:
    ```html
    <!-- Comment this line: -->
-   <!-- <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script> -->
+   <!-- <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/nutrient-viewer.js"></script> -->
    ```
 
 2. **Run with npm flag**:

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "drag-drop": "^7.2.0",
         "serve": "^13.0.4"
       },
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "drag-drop": "^7.2.0",
     "serve": "^13.0.4"
   },

--- a/examples/webpack/src/index.html
+++ b/examples/webpack/src/index.html
@@ -9,7 +9,7 @@
     <title>Nutrient</title>
     <link rel="stylesheet" href="./index.css" />
     <!-- Load Nutrient Web SDK from CDN (comment out to use npm package instead) -->
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.14.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.15.0/nutrient-viewer.js"></script>
   </head>
   <body id="body">
     <header>


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Type

- [ ] New framework example
- [ ] Update existing example
- [ ] SDK version bump
- [ ] Bug fix
- [ ] Repo infrastructure (CI, scripts, docs)

## Checklist

- [ ] `npm run format` passes (Biome)
- [ ] Example has `start` and `start:e2e` scripts in `package.json`
- [ ] `SERVER_DIR=examples/<name> npm run test` passes (Playwright smoke test)
- [ ] `README.md` included with prerequisites, setup, and usage
- [ ] Uses current pinned `@nutrient-sdk/viewer` version
