### PR TITLE
Update PWA to latest Nutrient SDK

### DIFF
--- a/examples/pwa/package-lock.json
+++ b/examples/pwa/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.14.0",
+        "@nutrient-sdk/viewer": "1.15.0",
         "idb": "^2.1.3",
         "serve": "^14.2.4",
         "workbox-sw": "^7.4.0"
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.14.0.tgz",
-      "integrity": "sha512-TMH/pQDnfOPohZMOCeU7AYUXdQBlScFG99HutmMHh9AGTUokoeS8up5kfO+srpeWLLXFZEubzr8fQvBuxYKDvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.15.0.tgz",
+      "integrity": "sha512-jk5yIHHtY4duHO3Ohly+5wz6IoGLzuVXGMSa/IuWZxm7b8mrZ/Ale1C4eaImXmnjUrD45uf6ThsKLBIKYyP0Fg==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/pwa/package.json
+++ b/examples/pwa/package.json
@@ -25,7 +25,7 @@
     "start:e2e": "npm run build && serve ./dist"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.14.0",
+    "@nutrient-sdk/viewer": "1.15.0",
     "idb": "^2.1.3",
     "serve": "^14.2.4",
     "workbox-sw": "^7.4.0"


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

## Type

- [ ] New framework example
- [ ] Update existing example
- [ ] SDK version bump
- [ ] Bug fix
- [ ] Repo infrastructure (CI, scripts, docs)

## Checklist

- [ ] `npm run format` passes (Biome)
- [ ] Example has `start` and `start:e2e` scripts in `package.json`
- [ ] `SERVER_DIR=examples/<name> npm run test` passes (Playwright smoke test)
- [ ] `README.md` included with prerequisites, setup, and usage
- [ ] Uses current pinned `@nutrient-sdk/viewer` version
