### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check Biome Version
         run: ./scripts/check-biome-version.sh
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2.7.1
         with:
           version: "1.9.4"
       - name: Run Biome

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
         run: npm exec playwright install chromium --with-deps
       - name: Run Playwright tests
         run: npm run e2e-tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
Context: https://pspdfkit.slack.com/archives/C03LUSTQYTF/p1780907940938109?thread_ts=1780905830.180029&cid=C03LUSTQYTF

## Summary

Remediates GitHub Actions supply-chain risk by replacing mutable major-version tags on external actions with verified full-length commit SHAs resolved from each action's **official upstream repository**.

Each pin stays within the same major version that was previously floating, so no major-version upgrade occurs and workflow behavior is preserved.

## Actions pinned

| Action (old ref) | New full SHA | Tag | Notes |
|---|---|---|---|
| `actions/checkout@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | `v4.3.1` | lightweight tag |
| `biomejs/setup-biome@v2` | `4c91541eaada48f67d7dbd7833600ce162b68f51` | `v2.7.1` | annotated tag → peeled commit pinned |
| `actions/setup-node@v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | `v4.4.0` | lightweight tag |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `v4.6.2` | lightweight tag |

## Files changed
- `.github/workflows/biome.yml` — `actions/checkout`, `biomejs/setup-biome`
- `.github/workflows/playwright.yml` — `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`

`actions/checkout` appeared in both workflows and was pinned to the same SHA in each.

## Verification
Tags/SHAs resolved via `git ls-remote --tags https://github.com/<owner>/<repo>.git` against the official upstream repositories. The `setup-biome` tag is annotated, so the peeled `refs/tags/v2.7.1^{}` commit was pinned rather than the tag-object SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)