### PR TITLE
Update examples with Nutrient SDK version 1.16.1

### DIFF
--- a/examples/angular/package-lock.json
+++ b/examples/angular/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^21.2.0",
         "@angular/platform-browser-dynamic": "^21.2.0",
         "@angular/router": "^21.2.0",
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "~0.16.1"
@@ -4709,9 +4709,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/platform-browser-dynamic": "^21.2.0",
     "@angular/router": "^21.2.0",
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "~0.16.1"

--- a/examples/angular/tsconfig.json
+++ b/examples/angular/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "strict": true,
-    "skipLibCheck": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,

--- a/examples/electron-nodeintegration/package-lock.json
+++ b/examples/electron-nodeintegration/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0"
+        "@nutrient-sdk/viewer": "1.16.1"
       },
       "devDependencies": {
         "@electron/packager": "^19.1.0",
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/electron-nodeintegration/package.json
+++ b/examples/electron-nodeintegration/package.json
@@ -29,6 +29,6 @@
     "electron": "^41.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.16.1"
   }
 }

--- a/examples/electron/package-lock.json
+++ b/examples/electron/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-electron-example",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0"
+        "@nutrient-sdk/viewer": "1.16.1"
       },
       "devDependencies": {
         "@electron/packager": "^19.1.0",
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -28,6 +28,6 @@
     "electron": "^41.2.0"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.16.1"
   }
 }

--- a/examples/elm/package-lock.json
+++ b/examples/elm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0"
+        "@nutrient-sdk/viewer": "1.16.1"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^14.0.0",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/elm/package.json
+++ b/examples/elm/package.json
@@ -9,7 +9,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.16.1"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^14.0.0",

--- a/examples/gatsbyjs/package-lock.json
+++ b/examples/gatsbyjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "gatsby": "^5.16.1",
         "gatsby-source-filesystem": "^5.16.0",
         "react": "^18.3.1",
@@ -3140,9 +3140,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/gatsbyjs/package.json
+++ b/examples/gatsbyjs/package.json
@@ -17,7 +17,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "gatsby": "^5.16.1",
     "gatsby-source-filesystem": "^5.16.0",
     "react": "^18.3.1",

--- a/examples/javascript-vite/index.html
+++ b/examples/javascript-vite/index.html
@@ -6,7 +6,7 @@
     <title>Nutrient Web SDK - JavaScript + Vite Example</title>
     <link rel="stylesheet" href="/src/style.css" />
     <!-- Load Nutrient Web SDK from CDN (comment out or remove when using npm package) -->
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/nutrient-viewer.js"></script>
   </head>
   <body>
     <header>

--- a/examples/javascript-vite/package-lock.json
+++ b/examples/javascript-vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "drag-drop": "^7.2.0"
       },
       "devDependencies": {
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/javascript-vite/package.json
+++ b/examples/javascript-vite/package.json
@@ -13,7 +13,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "drag-drop": "^7.2.0"
   },
   "devDependencies": {

--- a/examples/laravel/package-lock.json
+++ b/examples/laravel/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "laravel",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0"
+        "@nutrient-sdk/viewer": "1.16.1"
       },
       "devDependencies": {
         "axios": "^1.15.0",
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/laravel/package.json
+++ b/examples/laravel/package.json
@@ -16,7 +16,7 @@
     "postcss": "^8.5.9"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.16.1"
   },
   "overrides": {
     "webpack-dev-server": "^5.2.3",

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "copy-webpack-plugin": "^14.0.0",
         "next": "^15.5.8",
         "react": "^19.2.3",
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "copy-webpack-plugin": "^14.0.0",
     "next": "^15.5.8",
     "react": "^19.2.3",

--- a/examples/nuxtjs/package-lock.json
+++ b/examples/nuxtjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-nuxtjs",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "nuxt": "^3.20.2",
         "unstorage": "^1.17.5",
         "vue": "^3.5.25"
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -11,7 +11,7 @@
     "start:e2e": "npm run dev"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "nuxt": "^3.20.2",
     "unstorage": "^1.17.5",
     "vue": "^3.5.25"

--- a/examples/pwa/package-lock.json
+++ b/examples/pwa/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "idb": "^2.1.3",
         "serve": "^14.2.4",
         "workbox-sw": "^7.4.0"
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/pwa/package.json
+++ b/examples/pwa/package.json
@@ -25,7 +25,7 @@
     "start:e2e": "npm run build && serve ./dist"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "idb": "^2.1.3",
     "serve": "^14.2.4",
     "workbox-sw": "^7.4.0"

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -3000,9 +3000,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -29,7 +29,7 @@
     "start:e2e": "npm run start"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
+++ b/examples/salesforce/force-app/main/default/pages/Nutrient_InitNutrient.page
@@ -4,7 +4,7 @@
 
     <script type="text/javascript"> __sfdcSessionId = '{!$Api.Session_Id}';</script>
     <script src="../../soap/ajax/54.0/connection.js" type="text/javascript"></script>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/nutrient-viewer.js" type="text/javascript"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/nutrient-viewer.js" type="text/javascript"></script>
     <script type="text/javascript">
 
         var recId = '{!fileDetail}';
@@ -13,7 +13,7 @@
         var contVersion;
         var state;
         var pdf;
-        var baseUrl = "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/";
+        var baseUrl = "https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/";
 
         const saveButton = {
             type: "custom",

--- a/examples/salesforce/package-lock.json
+++ b/examples/salesforce/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0"
+        "@nutrient-sdk/viewer": "1.16.1"
       },
       "devDependencies": {
         "@lwc/eslint-plugin-lwc": "^1.1.2",
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/salesforce/package.json
+++ b/examples/salesforce/package.json
@@ -48,6 +48,6 @@
     ]
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.16.1"
   }
 }

--- a/examples/svelte-kit/package.json
+++ b/examples/svelte-kit/package.json
@@ -35,6 +35,6 @@
     }
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.15.1"
   }
 }

--- a/examples/svelte-kit/package.json
+++ b/examples/svelte-kit/package.json
@@ -35,6 +35,6 @@
     }
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.15.1"
+    "@nutrient-sdk/viewer": "1.16.1"
   }
 }

--- a/examples/svelte-kit/pnpm-lock.yaml
+++ b/examples/svelte-kit/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@nutrient-sdk/viewer':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.16.1
+        version: 1.16.1
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
@@ -254,8 +254,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.15.1':
-    resolution: {integrity: sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==}
+  '@nutrient-sdk/viewer@1.16.1':
+    resolution: {integrity: sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==}
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
@@ -1003,7 +1003,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@nutrient-sdk/viewer@1.15.1':
+  '@nutrient-sdk/viewer@1.16.1':
     dependencies:
       '@types/react': 18.3.19
 

--- a/examples/svelte-kit/pnpm-lock.yaml
+++ b/examples/svelte-kit/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@nutrient-sdk/viewer':
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.15.1
+        version: 1.15.1
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
@@ -254,8 +254,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.16.0':
-    resolution: {integrity: sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==}
+  '@nutrient-sdk/viewer@1.15.1':
+    resolution: {integrity: sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==}
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
@@ -1003,7 +1003,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@nutrient-sdk/viewer@1.16.0':
+  '@nutrient-sdk/viewer@1.15.1':
     dependencies:
       '@types/react': 18.3.19
 

--- a/examples/svelte/package-lock.json
+++ b/examples/svelte/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "sirv-cli": "^2.0.2"
       },
       "devDependencies": {
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -21,7 +21,7 @@
     "svelte": "^5.53.6"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "sirv-cli": "^2.0.2"
   },
   "overrides": {

--- a/examples/typescript-vite/index.html
+++ b/examples/typescript-vite/index.html
@@ -7,7 +7,7 @@
     <title>Nutrient Web SDK viewer — TypeScript example</title>
   </head>
   <body>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/nutrient-viewer.js"></script>
     <div class="container"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/examples/typescript-vite/package-lock.json
+++ b/examples/typescript-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-typescript-vite-example",
       "version": "0.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0"
+        "@nutrient-sdk/viewer": "1.16.1"
       },
       "devDependencies": {
         "typescript": "^5.9.2",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/typescript-vite/package.json
+++ b/examples/typescript-vite/package.json
@@ -14,6 +14,6 @@
     "vite": "^8.0.9"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0"
+    "@nutrient-sdk/viewer": "1.16.1"
   }
 }

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "serve": "^13.0.4"
       },
       "devDependencies": {
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -21,7 +21,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "serve": "^13.0.4"
   },
   "devDependencies": {

--- a/examples/typescript/src/index.html
+++ b/examples/typescript/src/index.html
@@ -8,7 +8,7 @@
     />
     <title>Nutrient Web SDK - Typescript example</title>
     <link rel="stylesheet" href="index.css" />
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/nutrient-viewer.js"></script>
   </head>
   <body>
     <div>

--- a/examples/vite/package-lock.json
+++ b/examples/vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -26,7 +26,7 @@
     "start:e2e": "vite --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/examples/vue-composition-api/package.json
+++ b/examples/vue-composition-api/package.json
@@ -11,7 +11,7 @@
     "type-check": "vue-tsc --build"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.15.1",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/vue-composition-api/package.json
+++ b/examples/vue-composition-api/package.json
@@ -11,7 +11,7 @@
     "type-check": "vue-tsc --build"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.15.1",
+    "@nutrient-sdk/viewer": "1.16.1",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/vue-composition-api/pnpm-lock.yaml
+++ b/examples/vue-composition-api/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@nutrient-sdk/viewer':
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.16.1
+        version: 1.16.1
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@5.9.3)
@@ -395,8 +395,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.15.1':
-    resolution: {integrity: sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==}
+  '@nutrient-sdk/viewer@1.16.1':
+    resolution: {integrity: sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==}
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
@@ -1612,7 +1612,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@nutrient-sdk/viewer@1.15.1':
+  '@nutrient-sdk/viewer@1.16.1':
     dependencies:
       '@types/react': 18.3.19
 

--- a/examples/vue-composition-api/pnpm-lock.yaml
+++ b/examples/vue-composition-api/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@nutrient-sdk/viewer':
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.15.1
+        version: 1.15.1
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@5.9.3)
@@ -395,8 +395,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nutrient-sdk/viewer@1.16.0':
-    resolution: {integrity: sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==}
+  '@nutrient-sdk/viewer@1.15.1':
+    resolution: {integrity: sha512-VRj05CGGMoXZZbvWJSBBgYzYoCRdwOPne1IWFNr/l0hkyB5ijKoVh8m94O6w3Ru8cW0OnBv4VfjxJQK9Mci6Yg==}
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
@@ -1612,7 +1612,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
-  '@nutrient-sdk/viewer@1.16.0':
+  '@nutrient-sdk/viewer@1.15.1':
     dependencies:
       '@types/react': 18.3.19
 

--- a/examples/vue/package-lock.json
+++ b/examples/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nutrient-web-example-vue",
       "version": "1.0.0",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "vue": "^3.5.32"
       },
       "devDependencies": {
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -10,7 +10,7 @@
     "start:e2e": "npm run dev -- --port 3000"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "vue": "^3.5.32"
   },
   "devDependencies": {

--- a/examples/webpack/README.md
+++ b/examples/webpack/README.md
@@ -50,7 +50,7 @@ To use the npm package bundled with webpack instead of CDN:
 1. **Comment out the CDN script** in `src/index.html`:
    ```html
    <!-- Comment this line: -->
-   <!-- <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/nutrient-viewer.js"></script> -->
+   <!-- <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/nutrient-viewer.js"></script> -->
    ```
 
 2. **Run with npm flag**:

--- a/examples/webpack/package-lock.json
+++ b/examples/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "drag-drop": "^7.2.0",
         "serve": "^13.0.4"
       },
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -20,7 +20,7 @@
   "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
   "readme": "https://www.nutrient.io/guides/web",
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "drag-drop": "^7.2.0",
     "serve": "^13.0.4"
   },

--- a/examples/webpack/src/index.html
+++ b/examples/webpack/src/index.html
@@ -9,7 +9,7 @@
     <title>Nutrient</title>
     <link rel="stylesheet" href="./index.css" />
     <!-- Load Nutrient Web SDK from CDN (comment out to use npm package instead) -->
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.0/nutrient-viewer.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@1.16.1/nutrient-viewer.js"></script>
   </head>
   <body id="body">
     <header>


### PR DESCRIPTION
## What

Updates all examples to the released @nutrient-sdk/viewer 1.16.1 (via the release flow's update script), with two follow-ups:

- Pins the two pnpm-based examples (vue-composition-api, svelte-kit) explicitly to 1.16.1 — the script's `@latest` resolution served stale registry metadata again, same as during the 1.16.0 bump.
- Removes `skipLibCheck` from the Angular example, restoring strict lib checking now that the 1.16.1 typings fix WEB-4498. This makes the Angular example a standing regression test for the published declarations.

## Type

- [ ] New framework example
- [ ] Update existing example
- [x] SDK version bump
- [ ] Bug fix
- [ ] Repo infrastructure (CI, scripts, docs)

## Checklist

- [x] `npm run format` passes (Biome)
- [ ] Example has `start` and `start:e2e` scripts in `package.json` (n/a — version bump)
- [ ] `SERVER_DIR=examples/<name> npm run test` passes (Playwright smoke test) (CI covers; Angular run now also validates the typings)
- [ ] `README.md` included (n/a)
- [x] Uses current pinned `@nutrient-sdk/viewer` version