### PR TITLE
Update PWA to latest Nutrient SDK

### DIFF
--- a/examples/pwa/package-lock.json
+++ b/examples/pwa/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
-        "@nutrient-sdk/viewer": "1.16.0",
+        "@nutrient-sdk/viewer": "1.16.1",
         "idb": "^2.1.3",
         "serve": "^14.2.4",
         "workbox-sw": "^7.4.0"
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@nutrient-sdk/viewer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.0.tgz",
-      "integrity": "sha512-Hht1TaV75E2d1X/BrE736BnkR37pOzn2kosEvCQFazyPDoLHoxppWi7pWtx7jZptAr0n3nW0lYekCmj88kx/eA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@nutrient-sdk/viewer/-/viewer-1.16.1.tgz",
+      "integrity": "sha512-bOSlA2WAe91qPdKBN+iY59o7jc5ccaMJIRELaVh13I2e+4d614T4JLk/xsG2YWjVFZkiLKhXipYkVdsDzYMMMA==",
       "license": "SEE LICENSE IN https://www.nutrient.io/legal/Nutrient_SDK_User_Evaluation_Subscription_Agreement",
       "dependencies": {
         "@types/react": "^18.0.0"

--- a/examples/pwa/package.json
+++ b/examples/pwa/package.json
@@ -25,7 +25,7 @@
     "start:e2e": "npm run build && serve ./dist"
   },
   "dependencies": {
-    "@nutrient-sdk/viewer": "1.16.0",
+    "@nutrient-sdk/viewer": "1.16.1",
     "idb": "^2.1.3",
     "serve": "^14.2.4",
     "workbox-sw": "^7.4.0"


### PR DESCRIPTION
## What

Updates the PWA example to @nutrient-sdk/viewer 1.16.1 (release flow's update-pwa-app task). Companion to #91 (examples bump). License key update skipped — existing key still valid.

## Type

- [ ] New framework example
- [ ] Update existing example
- [x] SDK version bump
- [ ] Bug fix
- [ ] Repo infrastructure (CI, scripts, docs)

## Checklist

- [x] `npm run format` passes (Biome)
- [ ] Example has `start` and `start:e2e` scripts (n/a — version bump only)
- [ ] Playwright smoke test (CI covers)
- [ ] `README.md` (n/a)
- [x] Uses current pinned `@nutrient-sdk/viewer` version