### PR TITLE
Automate SDK bump PRs, and fix the CODEOWNERS and CDN updater bugs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Web SDK team owns all examples
-* @PSPDFKit/nickel
+* @PSPDFKit/web

--- a/.github/workflows/update-nutrient-sdk.yml
+++ b/.github/workflows/update-nutrient-sdk.yml
@@ -22,8 +22,12 @@ concurrency:
 
 jobs:
   update:
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ubuntu-latest
+    env:
+      # Root install runs `prepare`, which points core.hooksPath at .husky and
+      # would gate the bot's commit on lint-staged and the Biome version check.
+      HUSKY: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -51,6 +55,27 @@ jobs:
           VERSION: ${{ steps.check.outputs.version }}
         run: ./scripts/update-nutrient-in-examples.sh "$VERSION"
 
+      - name: Check every CDN reference was bumped
+        if: steps.check.outputs.should_update == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          # The CDN file map in update-nutrient-in-cdn.js is hand-maintained, so an
+          # example that gains a script tag without an entry is left behind in
+          # silence. examples/salesforce/README.md is exempt: its version is an
+          # illustration, not a pin.
+          stale="$(grep -rEn "pspdfkit-web@[0-9]+\.[0-9]+\.[0-9]+" examples/ \
+            --exclude-dir=node_modules --exclude-dir=dist \
+            --exclude-dir=.next --exclude-dir=.nuxt \
+            | grep -v "pspdfkit-web@${VERSION}" \
+            | grep -v '^examples/salesforce/README.md:' || true)"
+
+          if [ -n "$stale" ]; then
+            echo "CDN references not updated to ${VERSION}:" >&2
+            echo "$stale" >&2
+            exit 1
+          fi
+
       - name: Install root dependencies
         if: steps.check.outputs.should_update == 'true'
         run: pnpm install --frozen-lockfile
@@ -65,7 +90,7 @@ jobs:
 
       # A pull request opened with GITHUB_TOKEN does not trigger the Biome or
       # Playwright workflows, and main requires no status checks, so the bump
-      # would otherwise arrive with no signal at all. Verify it here instead.
+      # would otherwise arrive with no signal at all.
       - name: Run e2e smoke tests
         id: e2e
         if: steps.check.outputs.should_update == 'true'
@@ -89,9 +114,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          # Scoped to examples/: installing at the root can leave a stray
-          # package-lock.json, which is not gitignored.
-          git add examples/
+          # `pnpm run format` writes unsafe Biome fixes repository-wide, and a dev
+          # server may leave build output behind; neither belongs in a bump.
+          git add -u examples/
           if git diff --cached --quiet; then
             echo "Detection reported ${VERSION} was needed but nothing changed." >&2
             exit 1
@@ -108,12 +133,13 @@ jobs:
           BRANCH: ${{ steps.check.outputs.branch }}
           E2E_OUTCOME: ${{ steps.e2e.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BASE: ${{ github.ref_name }}
         run: |
           if [ "$E2E_OUTCOME" = "success" ]; then
             e2e_result="✅ passed"
             draft=""
           else
-            e2e_result="❌ failed — see the run log and the playwright-report artifact"
+            e2e_result="❌ failed. The failing examples are named at the end of the run log."
             draft="--draft"
           fi
 
@@ -126,7 +152,7 @@ jobs:
           pull request created by \`GITHUB_TOKEN\` does not trigger the Biome or
           Playwright workflows, so the checks tab here will be empty.
 
-          - Formatting (\`pnpm run format\`): applied
+          - Formatting (\`pnpm run format\`): applied to \`examples/\`
           - E2E smoke tests (\`pnpm run e2e-tests\`): ${e2e_result}
 
           [Workflow run](${RUN_URL})
@@ -135,6 +161,15 @@ jobs:
           gh pr create \
             --title "Update examples with Nutrient SDK version $VERSION" \
             --body-file /tmp/pr-body.md \
-            --base main \
+            --base "$BASE" \
             --head "$BRANCH" \
             $draft
+
+      - name: Fail the run when the e2e suite failed
+        if: steps.check.outputs.should_update == 'true' && steps.e2e.outcome != 'success'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          echo "::error::E2E failed for ${VERSION}. The pull request was opened as a draft,"
+          echo "::error::and GitHub does not request code owners on drafts."
+          exit 1

--- a/.github/workflows/update-nutrient-sdk.yml
+++ b/.github/workflows/update-nutrient-sdk.yml
@@ -1,0 +1,140 @@
+name: Update Nutrient SDK
+
+on:
+  schedule:
+    # Daily, deliberately off the hour: GitHub deprioritises schedules that
+    # bunch on :00, which delays them further.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump to. Defaults to the npm latest dist-tag."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .tool-versions
+
+      - name: Check for a new SDK release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: ./scripts/check-nutrient-update.sh "${REQUESTED_VERSION:-}"
+
+      - name: Bump the SDK in every example
+        if: steps.check.outputs.should_update == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: ./scripts/update-nutrient-in-examples.sh "$VERSION"
+
+      - name: Install root dependencies
+        if: steps.check.outputs.should_update == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Format
+        if: steps.check.outputs.should_update == 'true'
+        run: pnpm run format
+
+      - name: Install Playwright browsers
+        if: steps.check.outputs.should_update == 'true'
+        run: pnpm exec playwright install chromium --with-deps
+
+      # A pull request opened with GITHUB_TOKEN does not trigger the Biome or
+      # Playwright workflows, and main requires no status checks, so the bump
+      # would otherwise arrive with no signal at all. Verify it here instead.
+      - name: Run e2e smoke tests
+        id: e2e
+        if: steps.check.outputs.should_update == 'true'
+        continue-on-error: true
+        run: pnpm run e2e-tests
+
+      - name: Upload Playwright report
+        if: steps.check.outputs.should_update == 'true' && steps.e2e.outcome != 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Commit and push the bump
+        if: steps.check.outputs.should_update == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+          BRANCH: ${{ steps.check.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          # Scoped to examples/: installing at the root can leave a stray
+          # package-lock.json, which is not gitignored.
+          git add examples/
+          if git diff --cached --quiet; then
+            echo "Detection reported ${VERSION} was needed but nothing changed." >&2
+            exit 1
+          fi
+          git commit -m "Update examples with Nutrient SDK version $VERSION"
+          git push origin "$BRANCH"
+
+      - name: Open the pull request
+        if: steps.check.outputs.should_update == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.check.outputs.version }}
+          CURRENT: ${{ steps.check.outputs.current }}
+          BRANCH: ${{ steps.check.outputs.branch }}
+          E2E_OUTCOME: ${{ steps.e2e.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$E2E_OUTCOME" = "success" ]; then
+            e2e_result="✅ passed"
+            draft=""
+          else
+            e2e_result="❌ failed — see the run log and the playwright-report artifact"
+            draft="--draft"
+          fi
+
+          cat > /tmp/pr-body.md <<BODY
+          Automated bump of \`@nutrient-sdk/viewer\` from ${CURRENT} to ${VERSION}.
+
+          ## Verification
+
+          Checks ran inside the workflow before this pull request was opened. A
+          pull request created by \`GITHUB_TOKEN\` does not trigger the Biome or
+          Playwright workflows, so the checks tab here will be empty.
+
+          - Formatting (\`pnpm run format\`): applied
+          - E2E smoke tests (\`pnpm run e2e-tests\`): ${e2e_result}
+
+          [Workflow run](${RUN_URL})
+          BODY
+
+          gh pr create \
+            --title "Update examples with Nutrient SDK version $VERSION" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH" \
+            $draft

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,8 @@ SERVER_DIR=examples/javascript-vite npm run test
 # Audit and fix vulnerabilities across all examples
 npm run audit-fix
 
-# Bump Nutrient SDK version in all examples
-npm run update-nutrient-version
+# Bump Nutrient SDK version in all examples (version is required)
+npm run update-nutrient-version -- 1.21.0
 ```
 
 ## Adding a New Example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ nutrient-web-examples/
 │   ├── audit-dependencies.sh     # npm audit fix across examples
 │   ├── update-nutrient-in-examples.sh  # Bump SDK version everywhere
 │   ├── update-nutrient-in-cdn.js       # Update CDN URLs
+│   ├── check-nutrient-update.sh        # Detect a new SDK release (CI)
 │   └── check-biome-version.sh    # Verify Biome version consistency
 ├── playwright.config.ts      # Playwright config (uses SERVER_DIR env var)
 └── biome.json                # Biome formatter config
@@ -124,6 +125,10 @@ svelte-kit, vue-composition-api.
 
 - **Biome** — Code formatting check on every push/PR
 - **Playwright** — Smoke tests on push/PR to main (installs all deps, runs e2e)
+- **Update Nutrient SDK** — Daily check for a new `@nutrient-sdk/viewer` release.
+  Bumps every example, runs Biome and the e2e suite inside the job, then opens a
+  PR (draft if e2e failed). `@PSPDFKit/web` is requested via CODEOWNERS. Can be
+  run on demand via `workflow_dispatch`, optionally against a specific version.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ SERVER_DIR=examples/javascript-vite npm run test
 npm run audit-fix
 
 # Bump Nutrient SDK version in all examples (version is required)
-npm run update-nutrient-version -- 1.21.0
+npm run update-nutrient-version -- <version>
 ```
 
 ## Adding a New Example
@@ -126,9 +126,12 @@ svelte-kit, vue-composition-api.
 - **Biome** — Code formatting check on every push/PR
 - **Playwright** — Smoke tests on push/PR to main (installs all deps, runs e2e)
 - **Update Nutrient SDK** — Daily check for a new `@nutrient-sdk/viewer` release.
-  Bumps every example, runs Biome and the e2e suite inside the job, then opens a
-  PR (draft if e2e failed). `@PSPDFKit/web` is requested via CODEOWNERS. Can be
-  run on demand via `workflow_dispatch`, optionally against a specific version.
+  Bumps every example listed in `update-nutrient-in-examples.sh`, formats with
+  Biome, runs the e2e suite inside the job, then opens a PR. A passing suite
+  opens it ready for review, so CODEOWNERS requests `@PSPDFKit/web`; a failing
+  one opens it as a draft and fails the run, because GitHub does not request
+  code owners on drafts. Can be run on demand via `workflow_dispatch`,
+  optionally against a specific version.
 
 ## Code Style
 

--- a/scripts/check-nutrient-update.sh
+++ b/scripts/check-nutrient-update.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-# Decides whether a Nutrient SDK bump is needed, and refuses to start one that
-# is already in flight. Writes version/branch/should_update to $GITHUB_OUTPUT.
+# Decides whether a Nutrient SDK bump is needed, refusing one already in flight.
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="${SCRIPT_DIR}/.."
 
-# Every example tracked by update-nutrient-in-examples.sh is held at the same
-# version, so any one of them reports the version the repository is on.
+# Every example is held at the same version, so one of them reports the version
+# the repository is on.
 REFERENCE_EXAMPLE="react"
 
 DIST_TAGS_URL="https://registry.npmjs.org/-/package/@nutrient-sdk/viewer/dist-tags"
@@ -17,7 +16,7 @@ requested="${1:-}"
 if [ -n "${requested}" ]; then
   latest="${requested}"
 else
-  latest="$(curl -fsSL --retry 3 --retry-delay 2 "${DIST_TAGS_URL}" | jq -r '.latest')"
+  latest="$(curl -fsSL --retry 3 --retry-delay 2 "${DIST_TAGS_URL}" | jq -er '.latest')"
 fi
 
 # Anything carrying a prerelease suffix is a nightly, never a release we ship.
@@ -26,24 +25,57 @@ if ! [[ "${latest}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
-current="$(jq -r '.dependencies["@nutrient-sdk/viewer"]' \
-  "${REPO_ROOT}/examples/${REFERENCE_EXAMPLE}/package.json")"
+# jq -r prints "null" and exits 0 for a missing key, which would silently
+# disable the already-on-this-version check.
+if ! current="$(jq -er '.dependencies["@nutrient-sdk/viewer"]' \
+  "${REPO_ROOT}/examples/${REFERENCE_EXAMPLE}/package.json")"; then
+  echo "examples/${REFERENCE_EXAMPLE} has no @nutrient-sdk/viewer dependency." >&2
+  echo "The reference example moved or was renamed; update REFERENCE_EXAMPLE." >&2
+  exit 1
+fi
 
 branch="update-examples-${latest}"
-should_update="true"
-reason="${current} -> ${latest}"
 
 if [ "${latest}" = "${current}" ]; then
   should_update="false"
   reason="already on ${latest}"
-elif git -C "${REPO_ROOT}" ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
-  should_update="false"
-  reason="branch ${branch} already exists"
-elif command -v gh >/dev/null 2>&1 &&
-  [ -n "$(gh pr list --state all --head "${branch}" --json number --jq '.[].number' 2>/dev/null)" ]; then
-  # A closed-without-merge bump must not be reopened on every scheduled run.
-  should_update="false"
-  reason="a pull request for ${branch} already exists"
+else
+  # --state all: a bump closed without merging must not be reopened on every
+  # scheduled run. A failed lookup must not read as "no pull request".
+  if ! pull_requests="$(gh pr list --state all --head "${branch}" \
+    --json number --jq '.[].number')"; then
+    echo "Could not list pull requests for ${branch}; refusing to guess." >&2
+    exit 1
+  fi
+
+  if [ -n "${pull_requests}" ]; then
+    should_update="false"
+    reason="a pull request for ${branch} already exists"
+  else
+    ls_remote_status=0
+    git -C "${REPO_ROOT}" ls-remote --exit-code --heads origin "${branch}" \
+      >/dev/null || ls_remote_status=$?
+
+    case "${ls_remote_status}" in
+      # An earlier run pushed the branch and then failed before opening its
+      # pull request. Skipping quietly would bury this version for good.
+      0)
+        echo "Branch ${branch} exists with no pull request, so an earlier run" >&2
+        echo "failed part-way. Delete it or open its pull request by hand." >&2
+        exit 1
+        ;;
+      # --exit-code reserves 2 for "no matching ref"; anything else is a real
+      # failure that must not read as "the branch is free".
+      2)
+        should_update="true"
+        reason="${current} -> ${latest}"
+        ;;
+      *)
+        echo "git ls-remote failed with status ${ls_remote_status}." >&2
+        exit 1
+        ;;
+    esac
+  fi
 fi
 
 echo "should_update=${should_update} (${reason})"

--- a/scripts/check-nutrient-update.sh
+++ b/scripts/check-nutrient-update.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Decides whether a Nutrient SDK bump is needed, and refuses to start one that
+# is already in flight. Writes version/branch/should_update to $GITHUB_OUTPUT.
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="${SCRIPT_DIR}/.."
+
+# Every example tracked by update-nutrient-in-examples.sh is held at the same
+# version, so any one of them reports the version the repository is on.
+REFERENCE_EXAMPLE="react"
+
+DIST_TAGS_URL="https://registry.npmjs.org/-/package/@nutrient-sdk/viewer/dist-tags"
+
+requested="${1:-}"
+
+if [ -n "${requested}" ]; then
+  latest="${requested}"
+else
+  latest="$(curl -fsSL --retry 3 --retry-delay 2 "${DIST_TAGS_URL}" | jq -r '.latest')"
+fi
+
+# Anything carrying a prerelease suffix is a nightly, never a release we ship.
+if ! [[ "${latest}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Refusing to act on non-stable version \"${latest}\"." >&2
+  exit 1
+fi
+
+current="$(jq -r '.dependencies["@nutrient-sdk/viewer"]' \
+  "${REPO_ROOT}/examples/${REFERENCE_EXAMPLE}/package.json")"
+
+branch="update-examples-${latest}"
+should_update="true"
+reason="${current} -> ${latest}"
+
+if [ "${latest}" = "${current}" ]; then
+  should_update="false"
+  reason="already on ${latest}"
+elif git -C "${REPO_ROOT}" ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+  should_update="false"
+  reason="branch ${branch} already exists"
+elif command -v gh >/dev/null 2>&1 &&
+  [ -n "$(gh pr list --state all --head "${branch}" --json number --jq '.[].number' 2>/dev/null)" ]; then
+  # A closed-without-merge bump must not be reopened on every scheduled run.
+  should_update="false"
+  reason="a pull request for ${branch} already exists"
+fi
+
+echo "should_update=${should_update} (${reason})"
+
+{
+  echo "version=${latest}"
+  echo "current=${current}"
+  echo "branch=${branch}"
+  echo "should_update=${should_update}"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/scripts/update-nutrient-in-cdn.js
+++ b/scripts/update-nutrient-in-cdn.js
@@ -5,14 +5,15 @@ const cdnOcurrences = {
   gatsbyjs: ["src/templates/Viewport.js"],
   "javascript-vite": ["index.html"],
   nuxtjs: ["components/NutrientContainer.vue"],
-  salesforce: [
-    "README.md",
-    "force-app/main/default/pages/Nutrient_InitNutrient.page",
-  ],
+  salesforce: ["force-app/main/default/pages/Nutrient_InitNutrient.page"],
   typescript: ["src/index.html"],
   "typescript-vite": ["index.html"],
   webpack: ["README.md", "src/index.html"],
 };
+
+const CDN_VERSION = /pspdfkit-web@\d+\.\d+\.\d+/g;
+
+const examplesDir = path.resolve(__dirname, "..", "examples");
 
 const example = process.argv[2];
 const version = process.argv[3];
@@ -29,15 +30,24 @@ if (!/^\d+\.\d+\.\d+$/.test(version)) {
   process.exit(1);
 }
 
-if (cdnOcurrences[example]) {
+// A key matching no directory is never looked up, so a typo in one is silent.
+const strayKeys = Object.keys(cdnOcurrences).filter(
+  (key) => !fs.existsSync(path.resolve(examplesDir, key)),
+);
+
+if (strayKeys.length > 0) {
+  console.error(`Keys matching no example directory: ${strayKeys.join(", ")}`);
+  process.exit(1);
+}
+
+if (Object.hasOwn(cdnOcurrences, example)) {
   console.log(`Updating CDN version in ${example} example.`);
 
   const filePaths = cdnOcurrences[example].map((relativePath) =>
-    path.resolve(__dirname, "..", "examples", example, relativePath),
+    path.resolve(examplesDir, example, relativePath),
   );
 
-  // Validate every file up front: a renamed or moved file would otherwise be
-  // skipped silently, or abort the run half-written across the example.
+  // Up front: a renamed file would otherwise abort the run half-written.
   const missing = filePaths.filter((filePath) => !fs.existsSync(filePath));
 
   if (missing.length > 0) {
@@ -47,14 +57,20 @@ if (cdnOcurrences[example]) {
 
   for (const filePath of filePaths) {
     const template = fs.readFileSync(filePath, "utf8");
+    let replacements = 0;
 
-    fs.writeFileSync(
-      filePath,
-      template.replace(
-        /pspdfkit-web@([0-9]+.[0-9]+.[0-9]+)?/g,
-        `pspdfkit-web@${version}`,
-      ),
-    );
+    const updated = template.replace(CDN_VERSION, () => {
+      replacements += 1;
+      return `pspdfkit-web@${version}`;
+    });
+
+    // A zero-match replace rewrites the file byte-identical, reporting success.
+    if (replacements === 0) {
+      console.error(`No versioned CDN reference found in ${filePath}.`);
+      process.exit(1);
+    }
+
+    fs.writeFileSync(filePath, updated);
   }
 
   console.log(`Updated CDN version in ${example} example.`);

--- a/scripts/update-nutrient-in-cdn.js
+++ b/scripts/update-nutrient-in-cdn.js
@@ -1,39 +1,59 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const { execSync } = require("node:child_process");
 
 const cdnOcurrences = {
-  typescript: ["src/index.html"],
-  gatsby: ["src/templates/Viewport.js"],
-  salesforce: ["force-app/main/default/pages/Nutrient_InitNutrient.page"],
+  gatsbyjs: ["src/templates/Viewport.js"],
   "javascript-vite": ["index.html"],
+  nuxtjs: ["components/NutrientContainer.vue"],
+  salesforce: [
+    "README.md",
+    "force-app/main/default/pages/Nutrient_InitNutrient.page",
+  ],
+  typescript: ["src/index.html"],
   "typescript-vite": ["index.html"],
   webpack: ["README.md", "src/index.html"],
 };
 
 const example = process.argv[2];
+const version = process.argv[3];
+
+if (!example || !version) {
+  console.error(
+    "Usage: node scripts/update-nutrient-in-cdn.js <example> <version>",
+  );
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error(`Expected a semver version, got "${version}".`);
+  process.exit(1);
+}
 
 if (cdnOcurrences[example]) {
   console.log(`Updating CDN version in ${example} example.`);
 
-  for (const relativePath of cdnOcurrences[example]) {
-    const template = fs.readFileSync(
-      path.resolve(`./examples/${example}/${relativePath}`),
-      "utf8",
-    );
+  const filePaths = cdnOcurrences[example].map((relativePath) =>
+    path.resolve(__dirname, "..", "examples", example, relativePath),
+  );
 
-    const version = execSync("npm view @nutrient-sdk/viewer version")
-      .toString()
-      .trim();
+  // Validate every file up front: a renamed or moved file would otherwise be
+  // skipped silently, or abort the run half-written across the example.
+  const missing = filePaths.filter((filePath) => !fs.existsSync(filePath));
 
-    const updatedTemplate = template.replace(
-      /pspdfkit-web@([0-9]+.[0-9]+.[0-9]+)?/g,
-      `pspdfkit-web@${version}`,
-    );
+  if (missing.length > 0) {
+    console.error(`Expected CDN files are missing:\n${missing.join("\n")}`);
+    process.exit(1);
+  }
+
+  for (const filePath of filePaths) {
+    const template = fs.readFileSync(filePath, "utf8");
 
     fs.writeFileSync(
-      path.resolve(`./examples/${example}/${relativePath}`),
-      updatedTemplate,
+      filePath,
+      template.replace(
+        /pspdfkit-web@([0-9]+.[0-9]+.[0-9]+)?/g,
+        `pspdfkit-web@${version}`,
+      ),
     );
   }
 

--- a/scripts/update-nutrient-in-examples.sh
+++ b/scripts/update-nutrient-in-examples.sh
@@ -38,6 +38,9 @@ upgrade_npm_in_example() {
     npm install > /dev/null
 
     npm audit fix > /dev/null || true
+  else
+    echo "examples/${directory} has no lockfile, so nothing would be installed." >&2
+    exit 1
   fi
 
   popd > /dev/null

--- a/scripts/update-nutrient-in-examples.sh
+++ b/scripts/update-nutrient-in-examples.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+VERSION="${1:-}"
+
+if [ -z "${VERSION}" ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Expected a semver version, got \"${VERSION}\"." >&2
+  exit 1
+fi
+
 Green='\033[0;32m'
 Yellow='\033[0;33m'
 NoColor='\033[0m'
@@ -12,16 +24,16 @@ upgrade_npm_in_example() {
 
   pushd "${SCRIPT_DIR}/../examples/${directory}/"  > /dev/null
 
-  echo -e "\n${Green}Upgrading npm in ${Yellow}${directory}${Green} example${NoColor}"
+  echo -e "\n${Green}Upgrading ${Yellow}${directory}${Green} to ${Yellow}${VERSION}${NoColor}"
 
   if [ -f "pnpm-lock.yaml" ]; then
-    pnpm install @nutrient-sdk/viewer@latest --save --save-exact
+    pnpm install "@nutrient-sdk/viewer@${VERSION}" --save --save-exact
 
     pnpm install > /dev/null
 
     pnpm audit fix > /dev/null || true
   elif [ -f "package-lock.json" ]; then
-    npm install @nutrient-sdk/viewer@latest --save --save-exact
+    npm install "@nutrient-sdk/viewer@${VERSION}" --save --save-exact
 
     npm install > /dev/null
 
@@ -30,7 +42,7 @@ upgrade_npm_in_example() {
 
   popd > /dev/null
 
-  node ./scripts/update-nutrient-in-cdn.js "${directory}"
+  node "${SCRIPT_DIR}/update-nutrient-in-cdn.js" "${directory}" "${VERSION}"
 }
 
 upgrade_npm_in_example "webpack"


### PR DESCRIPTION
### ⚡ TL;DR
A new `@nutrient-sdk/viewer` release now opens its own bump PR, already formatted and e2e-tested, instead of waiting for someone to notice. Two silent bugs that let stale versions sit in the repo for months are fixed along the way.

### 🎯 What this improves
- 🤖 **No manual bumps**: a daily job detects a new release, bumps every example, and opens the PR by itself.
- 👀 **Reviewers actually get asked**: CODEOWNERS pointed at `@PSPDFKit/nickel`, a team that does not exist, so GitHub silently requested nobody on every PR in this repo.
- 🔎 **Stale CDN versions surface instead of hiding**: `examples/gatsbyjs` sat eight minor versions behind because of a one-character typo nothing was checking.
- 🛑 **Failures stop being green**: a run that pushes a branch and then dies, or an e2e suite that fails, now fails the job rather than reporting success.
- ♻️ **Closed bumps stay closed**: declining a version no longer means it reappears tomorrow, and every day after.

### 🔧 What changed
- **Was:** version bumps were run by hand via `npm run update-nutrient-version`; the CDN updater keyed one example as `gatsby` while the directory is `gatsbyjs`, so that entry was never looked up and never updated; CODEOWNERS named a nonexistent team.
- **Now:** `.github/workflows/update-nutrient-sdk.yml` runs daily (and on `workflow_dispatch`, optionally against a given version). `scripts/check-nutrient-update.sh` decides whether to act and refuses to start a bump already in flight. `update-nutrient-in-cdn.js` rejects a map key matching no directory, rejects a mapped file that is missing, and rejects a replace that matched nothing. A workflow-level grep then catches any example carrying a CDN tag that the map does not know about at all.
- **Impact:** no user-facing or API change. Repository automation and CI only.

### 🔍 Root cause
- **CDN staleness:** `cdnOcurrences` is a hand-maintained map from example name to file list. A key that matches no directory is simply never looked up, so the `gatsby`/`gatsbyjs` typo produced no error, no warning, and no diff. `examples/nuxtjs` had a second variant of the same failure: it was absent from the map entirely.
- **The replace could not fail either:** the old pattern `/pspdfkit-web@([0-9]+.[0-9]+.[0-9]+)?/g` made the version group optional, so a file with no version still "matched", got rewritten byte-identical, and was reported as updated.
- **CODEOWNERS:** GitHub treats an unresolvable team as a no-op rather than an error, so `@PSPDFKit/nickel` reviewed nothing and said nothing.

### 🤔 Why
- **Decision:** guard the hand-maintained map at three levels in the script, and add one independent check in the workflow. The script guards give a precise early error; the workflow grep is the one that catches an example missing from the map, which no in-script guard can see.
- **Alternative considered:** deriving the file map by scanning `examples/` for CDN tags, removing the hand-maintained list entirely. Rejected for this PR: it trades a small include-list for an exclude-list (`examples/salesforce/README.md` documents the CDN URL with a worked `@1.0.0` example and must never be bumped), and it rewrites a script this PR is already changing. Worth doing separately.
- **Decision:** run the e2e suite inside the bump job. A PR opened with `GITHUB_TOKEN` does not trigger the Biome or Playwright workflows, and `main` requires no status checks, so the bump would otherwise arrive with no signal at all.
- **Decision:** a failing suite opens the PR as a draft and fails the run. GitHub does not request code owners on drafts, so without the explicit failure the bad path would notify nobody while staying green.

### 🧪 How to test
- Detection, without opening anything:

```bash
./scripts/check-nutrient-update.sh            # 1.18.0 -> 1.21.0, should_update=true
./scripts/check-nutrient-update.sh 1.18.0     # already on 1.18.0
./scripts/check-nutrient-update.sh 1.19.0     # a pull request already exists
./scripts/check-nutrient-update.sh 1.20.0-nightly   # exits 1, prereleases are never shipped
```

- The CDN guard that reproduces the original bug. Rename the `gatsbyjs` key to `gatsby` and it now refuses to run:

```bash
node scripts/update-nutrient-in-cdn.js webpack 9.9.9
# Keys matching no example directory: gatsby
```

- Confirm the salesforce README is left alone while its Visualforce page is bumped:

```bash
node scripts/update-nutrient-in-cdn.js salesforce 9.9.9
grep -rn 'pspdfkit-web@' examples/salesforce/ | grep -v node_modules
git checkout -- examples/salesforce/
```

- Lint and version consistency:

```bash
npx @biomejs/biome@1.9.4 ci .
./scripts/check-biome-version.sh
```

- End to end, against a version already released:

```bash
gh workflow run update-nutrient-sdk.yml -f version=1.21.0
```

### ⚠️ Risks / notes
- 🔑 **Needs "Allow GitHub Actions to create and approve pull requests"** enabled for the repo, or the `gh pr create` step fails with a permissions error.
- 📉 **Two examples are still behind on this branch**: `nuxtjs` is on 1.3.0 and `gatsbyjs` on 1.8.0. This PR does not bump them; it makes the next scheduled run bump them and fail loudly if it cannot.
- 🧹 **Formatting is staged from `examples/` only**: `pnpm run format` writes unsafe Biome fixes repository-wide, so the commit step uses `git add -u examples/` and discards the rest.
- ⏱️ **The job installs every example and runs the full e2e suite**, so a bump run takes a while; the timeout is set to 90 minutes.
- 🧭 **`update-nutrient-in-examples.sh` still hard-codes its 20 example directories.** A new example is silently never bumped, which is the same class of drift this PR fixes in the CDN map. Left out because generalizing it changes which examples get bumped (`wasm-benchmark` pins a range deliberately) and needs its own verification.

