### PR TITLE
Address review feedback on the SDK bump automation

### DIFF
--- a/.github/workflows/update-nutrient-sdk.yml
+++ b/.github/workflows/update-nutrient-sdk.yml
@@ -67,12 +67,13 @@ jobs:
           #
           # -o prints one match per line rather than one line per match, so a
           # line carrying both a bumped and a stale reference cannot have the
-          # stale one dropped along with the whole line. -F keeps the dots in
-          # ${VERSION} literal instead of matching any character.
+          # stale one dropped along with the whole line. The exclusion escapes
+          # the dots in ${VERSION} and anchors on $, so 1.20.1 cannot swallow a
+          # stale 1.20.10 as a prefix of it.
           stale="$(grep -rEon "pspdfkit-web@[0-9]+\.[0-9]+\.[0-9]+" examples/ \
             --exclude-dir=node_modules --exclude-dir=dist \
             --exclude-dir=.next --exclude-dir=.nuxt \
-            | grep -vF "pspdfkit-web@${VERSION}" \
+            | grep -vE "pspdfkit-web@${VERSION//./\\.}$" \
             | grep -v '^examples/salesforce/README.md:' || true)"
 
           if [ -n "$stale" ]; then
@@ -164,9 +165,9 @@ jobs:
           BODY
 
           # Nothing retries a draft. The scheduled job treats any pull request
-          # for this branch as "handled", so without these instructions the
-          # version is parked on whoever opens the draft next, with no way to
-          # re-run the suite from the pull request itself.
+          # for this branch as "handled" whatever its state, so without these
+          # instructions the version is parked on whoever opens the draft next,
+          # with no way to re-run the suite from the pull request itself.
           if [ "$E2E_OUTCOME" != "success" ]; then
             cat >> /tmp/pr-body.md <<RECOVERY
 
@@ -174,16 +175,19 @@ jobs:
 
           The e2e suite failed, so this was opened as a draft and GitHub did not
           request code owners on it. It will not retry on its own: every future
-          scheduled run sees this pull request and skips ${VERSION}.
+          scheduled run sees this pull request and skips ${VERSION}. Re-running
+          the workflow for ${VERSION} will not help either, for the same reason.
 
           Pick one:
 
-          - **The failure is a flake, or is unrelated to the bump.** Check the
-            [run log](${RUN_URL}), then mark this ready for review and say in a
-            comment what you verified.
-          - **You want the bump re-attempted from scratch.** Close this pull
-            request, delete the \`${BRANCH}\` branch, then run
-            \`gh workflow run update-nutrient-sdk.yml -f version=${VERSION}\`.
+          - **You want the checks to run here.** Close this pull request and
+            reopen it. Reopening it yourself fires \`pull_request: reopened\`,
+            which the Biome and Playwright workflows act on, so they run against
+            this bump and report in the checks tab. Marking a draft ready for
+            review triggers nothing, so it is not a substitute.
+          - **The bump needs a fix.** Push it to \`${BRANCH}\`. A push from
+            your own account runs those same checks. Then mark this ready for
+            review.
           - **The bump is genuinely broken.** Close this pull request and leave
             the branch in place. ${VERSION} will not be proposed again.
           RECOVERY

--- a/.github/workflows/update-nutrient-sdk.yml
+++ b/.github/workflows/update-nutrient-sdk.yml
@@ -64,10 +64,15 @@ jobs:
           # example that gains a script tag without an entry is left behind in
           # silence. examples/salesforce/README.md is exempt: its version is an
           # illustration, not a pin.
-          stale="$(grep -rEn "pspdfkit-web@[0-9]+\.[0-9]+\.[0-9]+" examples/ \
+          #
+          # -o prints one match per line rather than one line per match, so a
+          # line carrying both a bumped and a stale reference cannot have the
+          # stale one dropped along with the whole line. -F keeps the dots in
+          # ${VERSION} literal instead of matching any character.
+          stale="$(grep -rEon "pspdfkit-web@[0-9]+\.[0-9]+\.[0-9]+" examples/ \
             --exclude-dir=node_modules --exclude-dir=dist \
             --exclude-dir=.next --exclude-dir=.nuxt \
-            | grep -v "pspdfkit-web@${VERSION}" \
+            | grep -vF "pspdfkit-web@${VERSION}" \
             | grep -v '^examples/salesforce/README.md:' || true)"
 
           if [ -n "$stale" ]; then
@@ -157,6 +162,32 @@ jobs:
 
           [Workflow run](${RUN_URL})
           BODY
+
+          # Nothing retries a draft. The scheduled job treats any pull request
+          # for this branch as "handled", so without these instructions the
+          # version is parked on whoever opens the draft next, with no way to
+          # re-run the suite from the pull request itself.
+          if [ "$E2E_OUTCOME" != "success" ]; then
+            cat >> /tmp/pr-body.md <<RECOVERY
+
+          ## This draft needs a human
+
+          The e2e suite failed, so this was opened as a draft and GitHub did not
+          request code owners on it. It will not retry on its own: every future
+          scheduled run sees this pull request and skips ${VERSION}.
+
+          Pick one:
+
+          - **The failure is a flake, or is unrelated to the bump.** Check the
+            [run log](${RUN_URL}), then mark this ready for review and say in a
+            comment what you verified.
+          - **You want the bump re-attempted from scratch.** Close this pull
+            request, delete the \`${BRANCH}\` branch, then run
+            \`gh workflow run update-nutrient-sdk.yml -f version=${VERSION}\`.
+          - **The bump is genuinely broken.** Close this pull request and leave
+            the branch in place. ${VERSION} will not be proposed again.
+          RECOVERY
+          fi
 
           gh pr create \
             --title "Update examples with Nutrient SDK version $VERSION" \

--- a/scripts/check-nutrient-update.sh
+++ b/scripts/check-nutrient-update.sh
@@ -9,6 +9,7 @@ REPO_ROOT="${SCRIPT_DIR}/.."
 # the repository is on.
 REFERENCE_EXAMPLE="react"
 
+PACKAGE_URL="https://registry.npmjs.org/@nutrient-sdk/viewer"
 DIST_TAGS_URL="https://registry.npmjs.org/-/package/@nutrient-sdk/viewer/dist-tags"
 
 requested="${1:-}"
@@ -23,6 +24,20 @@ fi
 if ! [[ "${latest}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Refusing to act on non-stable version \"${latest}\"." >&2
   exit 1
+fi
+
+# A dispatched version is typed by hand, and the dist-tag is not there to vouch
+# for it. Without this, a typo gets through detection and only surfaces as an
+# npm 404 well into the bump, long after the branch has been created.
+#
+# A version older than current is deliberately allowed: dispatching one is how a
+# bad release gets rolled back.
+if [ -n "${requested}" ]; then
+  if ! curl -fsSL --retry 3 --retry-delay 2 -o /dev/null \
+    "${PACKAGE_URL}/${requested}"; then
+    echo "@nutrient-sdk/viewer@${requested} is not published on the registry." >&2
+    exit 1
+  fi
 fi
 
 # jq -r prints "null" and exits 0 for a missing key, which would silently

--- a/scripts/check-nutrient-update.sh
+++ b/scripts/check-nutrient-update.sh
@@ -30,12 +30,26 @@ fi
 # for it. Without this, a typo gets through detection and only surfaces as an
 # npm 404 well into the bump, long after the branch has been created.
 #
-# A version older than current is deliberately allowed: dispatching one is how a
-# bad release gets rolled back.
+# No ordering check accompanies it, because none is needed: any version that has
+# been bumped before still has its pull request, and the check below refuses a
+# branch that already has one, whatever state that pull request is in.
+#
+# -f is deliberately absent so that a 404 and an unreachable registry stay
+# distinguishable; without it curl reports both as the same failure.
 if [ -n "${requested}" ]; then
-  if ! curl -fsSL --retry 3 --retry-delay 2 -o /dev/null \
-    "${PACKAGE_URL}/${requested}"; then
-    echo "@nutrient-sdk/viewer@${requested} is not published on the registry." >&2
+  curl_status=0
+  http_code="$(curl -sSL --retry 3 --retry-delay 2 -o /dev/null \
+    -w '%{http_code}' "${PACKAGE_URL}/${requested}")" || curl_status=$?
+
+  if [ "${curl_status}" -ne 0 ]; then
+    echo "Could not reach the npm registry to check ${requested}" \
+      "(curl exited ${curl_status})." >&2
+    exit 1
+  fi
+
+  if [ "${http_code}" != "200" ]; then
+    echo "@nutrient-sdk/viewer@${requested} is not published on the registry" \
+      "(HTTP ${http_code})." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
### ⚡ TL;DR

Follow-ups from the review of #101, then from the review of this PR. The stale-CDN guard had two blind spots, a hand-typed version was never checked against the registry, and a draft opened by a failing e2e run first told nobody what to do with it, then told them something that does not work.

### 🎯 What this improves

- 🔎 **The stale-CDN guard stops having blind spots**: a README line listing two CDN URLs no longer lets the stale one through, and `1.20.1` no longer hides a stale `1.20.10`.
- ⌨️ **A typo'd `workflow_dispatch` version fails in the first step**, naming the version and the registry's status code, instead of as an npm 404 twenty minutes into the bump. A registry outage now reads differently from a version that does not exist.
- 🧭 **A failed bump explains itself, correctly**: the draft it opens names the one action that actually attaches checks to it, and says plainly that re-dispatching the workflow will not.

### 🔧 What changed

- **`update-nutrient-sdk.yml`, stale-CDN check.** `grep -rEn ... | grep -v "pspdfkit-web@${VERSION}"` printed one line per matching *line*, and the exclusion then discarded that whole line, so a line holding both `pspdfkit-web@1.21.0` and `pspdfkit-web@1.8.0` was excluded on the strength of the fresh reference. `-o` makes each reference its own output line. The exclusion also matched the version as a substring, so `1.20.1` would have hidden a stale `1.20.10`; it now escapes the dots in `${VERSION}` and anchors on `$`.
- **`update-nutrient-sdk.yml`, draft PR body.** When the e2e suite fails the body gains a "This draft needs a human" section, because no checks are attached to the draft and every later scheduled run skips the version as "already handled". Its instructions now match what GitHub actually does: **close and reopen the pull request** to get Biome and Playwright to run against the bump, push a fix to the branch if one is needed, or close it and walk away. It also states that marking a draft ready for review triggers nothing, and that re-dispatching the workflow for the same version is refused.
- **`check-nutrient-update.sh`.** A dispatched version is now confirmed to exist on the registry before anything else runs. `-f` is deliberately absent so a 404 and an unreachable registry stay distinguishable, and the message carries the status code.
- **Impact:** no user-facing or API change. Repository automation only.

### 🤔 Why

- **Close and reopen, not close and re-dispatch.** `check-nutrient-update.sh` lists pull requests with `--state all`, so a closed draft still reads as "already handled" and a re-run exits with `should_update=false`. Reopening fires `pull_request: reopened` as the human who did it, and that is a default activity type for both `biome.yml` and `playwright.yml`. `ready_for_review` is not, so marking the draft ready attaches nothing.
- **No ordering check, and no rollback claim either.** An earlier revision of this PR claimed dispatching an older version was the rollback path. It is not: every released version already has an `update-examples-X` pull request, and the existing-PR check refuses those whatever state they are in. The comment now records the real reason no ordering check is needed — that check already covers it.
- **Not addressed here: `pnpm audit fix`.** #102 already fixes the invalid invocation on that line, so touching it here would only conflict.

### 🧪 How to test

The registry check, and what an old version really does:

```bash
./scripts/check-nutrient-update.sh 1.17.99   # not published, exits 1 naming "(HTTP 404)"
./scripts/check-nutrient-update.sh 1.17.0    # published, then refused: #96 already exists for that branch
./scripts/check-nutrient-update.sh           # dist-tag path, unchanged
```

Both grep blind spots, reproduced directly:

```bash
printf 'pspdfkit-web@1.20.10\npspdfkit-web@1.21.0 and pspdfkit-web@1.8.0\n' > /tmp/t.txt
grep -rEn  "pspdfkit-web@[0-9]+\.[0-9]+\.[0-9]+" /tmp/t.txt | grep -vF "pspdfkit-web@1.20.1"     # misses both
grep -rEon "pspdfkit-web@[0-9]+\.[0-9]+\.[0-9]+" /tmp/t.txt | grep -vE "pspdfkit-web@1\.20\.1$"  # reports both
```

### ✅ Verification

| Check | Result |
| --- | --- |
| `bash -n` on the script and on all ten workflow `run` blocks | pass |
| `check-nutrient-update.sh` with `1.17.99` / `1.17.0` / no version | exits 1 with `(HTTP 404)` / refused, a pull request for that branch exists / dist-tag path unchanged |
| Registry unreachable (`registry.npmjs.invalid`) | `curl` exits 6, reported as "could not reach", not as unpublished |
| CDN check step run against the real tree at `VERSION=1.20.0` | flags `nuxtjs` 1.3.0 and `gatsbyjs` 1.8.0, exempts `salesforce/README.md` |
| Same step at `VERSION=1.20.1` over a fixture tree | flags `1.20.10` and a stale `1.9.0` sharing a line with `1.20.1`; keeps `1.20.1` out |
| Both PR-body variants rendered with the step's own script | recovery section present only on failure, all variables substituted |
| `biome ci .` | pass, 138 files |

### ⚠️ Risks / notes

- 🌐 **The check step makes one extra registry request**, and only for a dispatched version; the scheduled path is untouched.
- 🚦 **The workflow has never run in CI.** A `workflow_dispatch` after merge is its first real test, as noted in review.
- 📌 **Still open from the review of #101**: generalizing the hard-coded example list in `update-nutrient-in-examples.sh`, now tracked as #104. It covers `update-nutrient-in-cdn.js` too, since the hand-maintained map there has the identical failure mode.

https://claude.ai/code/session_0117hJP3TxNWJxrg4YPMNNiS
